### PR TITLE
Afficher le header de la home

### DIFF
--- a/front-v2/angular.json
+++ b/front-v2/angular.json
@@ -31,7 +31,8 @@
             ],
             "styles": [
               "src/styles.scss",
-              "node_modules/@fortawesome/fontawesome-free/css/all.css"
+              "node_modules/@fortawesome/fontawesome-free/css/all.css",
+              "node_modules/@ngxpert/hot-toast/src/styles/styles.css"
             ],
             "scripts": []
           },

--- a/front-v2/package-lock.json
+++ b/front-v2/package-lock.json
@@ -19,6 +19,8 @@
         "@angular/service-worker": "^18.2.0",
         "@fortawesome/angular-fontawesome": "^0.15.0",
         "@fortawesome/fontawesome-free": "^6.6.0",
+        "@ngneat/overview": "^6.0.0",
+        "@ngxpert/hot-toast": "^3.0.2",
         "@use-gesture/vanilla": "10.3.1",
         "ngxtension": "4.0.0",
         "rxjs": "~7.8.0",
@@ -4481,6 +4483,18 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
+    "node_modules/@ngneat/overview": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/overview/-/overview-6.0.0.tgz",
+      "integrity": "sha512-pm4bAEYtnUl8q82dwjh5NN9HF0WTFEI58VtR12izp9Oaa2dtseX82VUArfb4fadmlbHpPMUwXHrsm0ORyWii2A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=17"
+      }
+    },
     "node_modules/@ngtools/webpack": {
       "version": "18.2.6",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.6.tgz",
@@ -4496,6 +4510,19 @@
         "@angular/compiler-cli": "^18.0.0",
         "typescript": ">=5.4 <5.6",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@ngxpert/hot-toast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ngxpert/hot-toast/-/hot-toast-3.0.2.tgz",
+      "integrity": "sha512-kxDI/BxKp5TdDd8pEb5k9iKTCfeyGR1MSjr9DKeItpkZl8D5ynFijSS96WQQgsKZUmHemYfoDymG6d15Q+lruQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">= 18.0.0",
+        "@ngneat/overview": "6.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/front-v2/package.json
+++ b/front-v2/package.json
@@ -26,6 +26,8 @@
     "@angular/service-worker": "^18.2.0",
     "@fortawesome/angular-fontawesome": "^0.15.0",
     "@fortawesome/fontawesome-free": "^6.6.0",
+    "@ngneat/overview": "^6.0.0",
+    "@ngxpert/hot-toast": "^3.0.2",
     "@use-gesture/vanilla": "10.3.1",
     "ngxtension": "4.0.0",
     "rxjs": "~7.8.0",

--- a/front-v2/src/app/app.component.spec.ts
+++ b/front-v2/src/app/app.component.spec.ts
@@ -13,10 +13,4 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
-
-  it(`should have the 'front-v2' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('front-v2');
-  });
 });

--- a/front-v2/src/app/app.component.ts
+++ b/front-v2/src/app/app.component.ts
@@ -8,6 +8,4 @@ import { RouterOutlet } from '@angular/router';
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
-export class AppComponent {
-  title = 'front-v2';
-}
+export class AppComponent {}

--- a/front-v2/src/app/app.config.ts
+++ b/front-v2/src/app/app.config.ts
@@ -2,9 +2,12 @@ import {
   ApplicationConfig,
   provideZoneChangeDetection,
   isDevMode,
+  LOCALE_ID,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
+import { registerLocaleData } from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
 import { ReactiveFormsModule } from '@angular/forms';
 import { routes } from './app.routes';
 import { provideServiceWorker } from '@angular/service-worker';
@@ -20,6 +23,8 @@ import { MonthsService } from './services/months/months.service';
 import { MONTHS_SERVICE } from './services/months/months.service.interface';
 import { MonthlyBudgetsStore } from './stores/monthlyBudgets.store';
 import { MONTHLY_BUDGETS_STORE } from './stores/monthlyBudgets.store.interface';
+
+registerLocaleData(localeFr);
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -37,6 +42,7 @@ export const appConfig: ApplicationConfig = {
       autoClose: true,
       dismissible: true,
     }),
+    { provide: LOCALE_ID, useValue: 'fr' },
     { provide: AUTHENTICATION_SERVICE, useClass: AuthenticationService },
     {
       provide: MONTH_TEMPLATES_SERVICE,

--- a/front-v2/src/app/app.config.ts
+++ b/front-v2/src/app/app.config.ts
@@ -11,6 +11,7 @@ import { provideServiceWorker } from '@angular/service-worker';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { AuthenticationService } from './services/authentication/authentication.service';
 import { BrowserModule } from '@angular/platform-browser';
+import { provideHotToastConfig } from '@ngxpert/hot-toast';
 import { AUTHENTICATION_SERVICE } from './services/authentication/authentication.service.interface';
 import { MonthTemplatesService } from './services/monthTemplates/monthTemplates.service';
 import { MONTH_TEMPLATES_SERVICE } from './services/monthTemplates/monthTemplates.service.interface';
@@ -30,6 +31,11 @@ export const appConfig: ApplicationConfig = {
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000',
+    }),
+    provideHotToastConfig({
+      position: 'top-center',
+      autoClose: true,
+      dismissible: true,
     }),
     { provide: AUTHENTICATION_SERVICE, useClass: AuthenticationService },
     {

--- a/front-v2/src/app/components/home/home.component.html
+++ b/front-v2/src/app/components/home/home.component.html
@@ -1,4 +1,25 @@
-@if (monthlyBudgets) {
-{{ monthlyBudgets().length }}
-}
+@if (currentMonth) {
+<header class="header">
+  <div class="header__month">
+    <span class="header-month__title">{{
+      currentMonth.date.toString() | dateNormalize
+    }}</span>
+  </div>
+  <div class="header__info">
+    <div class="header-info__balance">
+      <span class="header-info-balance__title">Solde courant :</span>
+      <span class="header-info-balance__amount">{{
+        currentMonth.dashboard.account.currentBalance | currency : "EUR"
+      }}</span>
+    </div>
+    <div class="header-info__balance">
+      <span class="header-info-balance__title">Solde prévisionnel :</span>
+      <span class="header-info-balance__amount">{{
+        currentMonth.dashboard.account.forecastBalance | currency : "EUR"
+      }}</span>
+    </div>
+  </div>
+</header>
+} @else { pas de mois }
+<div class="outflows"></div>
 <app-menu-footer></app-menu-footer>

--- a/front-v2/src/app/components/home/home.component.html
+++ b/front-v2/src/app/components/home/home.component.html
@@ -1,21 +1,28 @@
-@if (displayLoader) { <app-loader></app-loader> } @if (currentMonth) {
+@if (displayLoader) { <app-loader></app-loader> } @if (currentMonthlyBudget &&
+current !== null) {
 <header class="header">
   <div class="header__month">
+    <button class="header-month__navigation" (click)="getPreviousMonth()">
+      <i class="fa-solid fa-chevron-left"></i>
+    </button>
     <span class="header-month__title">{{
-      currentMonth.date.toString() | dateNormalize
+      current.date.toString() | dateNormalize
     }}</span>
+    <button class="header-month__navigation" (click)="getNextMonth()">
+      <i class="fa-solid fa-chevron-right"></i>
+    </button>
   </div>
   <div class="header__info">
     <div class="header-info__balance">
       <span class="header-info-balance__title">Solde courant :</span>
       <span class="header-info-balance__amount">{{
-        currentMonth.dashboard.account.currentBalance | currency : "EUR"
+        current.dashboard.account.currentBalance | currency : "EUR"
       }}</span>
     </div>
     <div class="header-info__balance">
       <span class="header-info-balance__title">Solde prévisionnel :</span>
       <span class="header-info-balance__amount">{{
-        currentMonth.dashboard.account.forecastBalance | currency : "EUR"
+        current.dashboard.account.forecastBalance | currency : "EUR"
       }}</span>
     </div>
   </div>

--- a/front-v2/src/app/components/home/home.component.html
+++ b/front-v2/src/app/components/home/home.component.html
@@ -1,4 +1,4 @@
-@if (currentMonth) {
+@if (displayLoader) { <app-loader></app-loader> } @if (currentMonth) {
 <header class="header">
   <div class="header__month">
     <span class="header-month__title">{{

--- a/front-v2/src/app/components/home/home.component.scss
+++ b/front-v2/src/app/components/home/home.component.scss
@@ -17,8 +17,16 @@
   background-color: var(--color-950);
   color: white;
   box-shadow: 0px 1px 10px 0 black;
-  padding: 30px 10px;
+  padding: 30px 20px;
   box-sizing: border-box;
+
+  &__month {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    justify-content: space-between;
+    width: 100%;
+  }
 
   &__info {
     display: flex;
@@ -29,6 +37,15 @@
 }
 
 .header-month {
+  &__navigation {
+    font-size: 30px;
+    border: none;
+    background: none;
+    color: white;
+    width: 20px;
+    padding: 0;
+  }
+
   &__title {
     @extend %title-20;
 

--- a/front-v2/src/app/components/home/home.component.scss
+++ b/front-v2/src/app/components/home/home.component.scss
@@ -30,7 +30,7 @@
 
 .header-month {
   &__title {
-    @extend %title-30;
+    @extend %title-20;
 
     text-transform: capitalize;
   }
@@ -62,7 +62,4 @@
   &__amount {
     font-weight: bold;
   }
-}
-
-.outflows {
 }

--- a/front-v2/src/app/components/home/home.component.scss
+++ b/front-v2/src/app/components/home/home.component.scss
@@ -1,0 +1,68 @@
+@import "../../../styles/variables";
+@import "../../../styles/typo";
+
+.header {
+  position: fixed;
+  top: 0;
+  left: 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  justify-content: space-around;
+  gap: 10px;
+  width: 100%;
+  height: 150px;
+  border-radius: 0 0 var(--radius-100) var(--radius-100);
+  background-color: var(--color-950);
+  color: white;
+  box-shadow: 0px 1px 10px 0 black;
+  padding: 30px 10px;
+  box-sizing: border-box;
+
+  &__info {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    width: 100%;
+  }
+}
+
+.header-month {
+  &__title {
+    @extend %title-30;
+
+    text-transform: capitalize;
+  }
+}
+
+.header-info {
+  &__balance {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 10px;
+    box-sizing: border-box;
+    border-right: 1px solid;
+
+    &:first-child {
+      padding-right: 40px;
+    }
+
+    &:last-child {
+      border: none;
+    }
+  }
+}
+
+.header-info-balance {
+  &__title {
+    font-size: var(--text-5);
+  }
+  &__amount {
+    font-weight: bold;
+  }
+}
+
+.outflows {
+}

--- a/front-v2/src/app/components/home/home.component.spec.ts
+++ b/front-v2/src/app/components/home/home.component.spec.ts
@@ -3,6 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 import { MONTHLY_BUDGETS_STORE } from '../../stores/monthlyBudgets.store.interface';
 import { signal } from '@angular/core';
+import { MONTHS_SERVICE } from '../../services/months/months.service.interface';
+import { of } from 'rxjs';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -16,6 +18,12 @@ describe('HomeComponent', () => {
           provide: MONTHLY_BUDGETS_STORE,
           useValue: {
             getAll: () => signal([]),
+          },
+        },
+        {
+          provide: MONTHS_SERVICE,
+          useValue: {
+            getUnarchivedMonths: () => of([]),
           },
         },
       ],

--- a/front-v2/src/app/components/home/home.component.ts
+++ b/front-v2/src/app/components/home/home.component.ts
@@ -26,7 +26,7 @@ import { DesignSystemModule } from '../../design-system/design-system.module';
   styleUrl: './home.component.scss',
 })
 export class HomeComponent {
-  monthlyBudgets: Signal<MonthlyBudget[]> | null = null;
+  currentMonthlyBudget: Signal<MonthlyBudget | null> | null = null;
   displayLoader = false;
 
   constructor(
@@ -35,7 +35,7 @@ export class HomeComponent {
     @Inject(MONTHS_SERVICE)
     private monthsService: MonthsServiceInterface
   ) {
-    if (!this.currentMonth) {
+    if (!this.currentMonthlyBudget) {
       this.displayLoader = true;
       this.monthsService
         .getUnarchivedMonths()
@@ -45,16 +45,24 @@ export class HomeComponent {
           })
         )
         .subscribe(() => {
-          this.monthlyBudgets = this.monthlyBudgetsStore.getAll();
+          this.currentMonthlyBudget = this.monthlyBudgetsStore.getCurrent();
         });
     }
   }
 
-  get currentMonth() {
-    if (!this.monthlyBudgets || !this.monthlyBudgets()[0]) {
-      return null;
+  get current() {
+    if (this.currentMonthlyBudget) {
+      return this.currentMonthlyBudget();
     }
 
-    return this.monthlyBudgets()[0];
+    return null;
+  }
+
+  getNextMonth() {
+    this.monthlyBudgetsStore.setNextMonth();
+  }
+
+  getPreviousMonth() {
+    this.monthlyBudgetsStore.setPreviousMonth();
   }
 }

--- a/front-v2/src/app/components/home/home.component.ts
+++ b/front-v2/src/app/components/home/home.component.ts
@@ -5,11 +5,13 @@ import {
   MonthlyBudgetsStoreInterface,
 } from '../../stores/monthlyBudgets.store.interface';
 import { MonthlyBudget } from '../../models/monthlyBudget.model';
+import { DateNormalizePipe } from '../../pipes/date-normalize.pipe';
+import { CurrencyPipe } from '@angular/common';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [MenuFooterComponent],
+  imports: [MenuFooterComponent, DateNormalizePipe, CurrencyPipe],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss',
 })
@@ -21,5 +23,13 @@ export class HomeComponent {
     private monthlyBudgetsStore: MonthlyBudgetsStoreInterface
   ) {
     this.monthlyBudgets = this.monthlyBudgetsStore.getAll();
+  }
+
+  get currentMonth() {
+    if (!this.monthlyBudgets || !this.monthlyBudgets()[0]) {
+      return null;
+    }
+
+    return this.monthlyBudgets()[0];
   }
 }

--- a/front-v2/src/app/components/month-creation/month-creation.component.html
+++ b/front-v2/src/app/components/month-creation/month-creation.component.html
@@ -127,6 +127,7 @@
         [type]="'submit'"
         [size]="'big'"
         [label]="'Créer'"
+        [loading]="creationLoader"
       ></app-button>
     </div>
   </div>

--- a/front-v2/src/app/components/month-creation/month-creation.component.scss
+++ b/front-v2/src/app/components/month-creation/month-creation.component.scss
@@ -89,10 +89,15 @@
     display: none;
     position: sticky;
     top: 55px;
+    height: 72px;
     background-color: white;
     padding: 10px;
     border: none;
     cursor: pointer;
+
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
 }
 

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -25,11 +25,6 @@ import { DesignSystemModule } from '../../design-system/design-system.module';
 import MonthsServiceInterface, {
   MONTHS_SERVICE,
 } from '../../services/months/months.service.interface';
-import { MonthlyBudget } from '../../models/monthlyBudget.model';
-import {
-  MONTHLY_BUDGETS_STORE,
-  MonthlyBudgetsStoreInterface,
-} from '../../stores/monthlyBudgets.store.interface';
 import { finalize } from 'rxjs';
 import { HotToastService } from '@ngxpert/hot-toast';
 
@@ -67,9 +62,7 @@ export class MonthCreationComponent implements OnInit, AfterViewInit {
     private renderer: Renderer2,
     @Inject(HotToastService) private toaster: HotToastService,
     @Inject(MONTHS_SERVICE)
-    private monthsService: MonthsServiceInterface,
-    @Inject(MONTHLY_BUDGETS_STORE)
-    private monthlyBudgetsStore: MonthlyBudgetsStoreInterface
+    private monthsService: MonthsServiceInterface
   ) {}
 
   ngAfterViewInit(): void {
@@ -140,9 +133,8 @@ export class MonthCreationComponent implements OnInit, AfterViewInit {
           this.creationLoader = false;
         })
       )
-      .subscribe((month: MonthlyBudget) => {
+      .subscribe(() => {
         this.toaster.success('Votre mois a bien été crée !');
-        this.monthlyBudgetsStore.addMonth(month);
         this.backToHome();
       });
   }

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -30,6 +30,8 @@ import {
   MONTHLY_BUDGETS_STORE,
   MonthlyBudgetsStoreInterface,
 } from '../../stores/monthlyBudgets.store.interface';
+import { finalize } from 'rxjs';
+import { HotToastService } from '@ngxpert/hot-toast';
 
 @Component({
   selector: 'app-month-creation',
@@ -56,12 +58,14 @@ export class MonthCreationComponent implements OnInit, AfterViewInit {
     weeklyBudgets: [],
     outflows: [],
   };
+  creationLoader = false;
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private fb: FormBuilder,
     private renderer: Renderer2,
+    @Inject(HotToastService) private toaster: HotToastService,
     @Inject(MONTHS_SERVICE)
     private monthsService: MonthsServiceInterface,
     @Inject(MONTHLY_BUDGETS_STORE)
@@ -128,9 +132,16 @@ export class MonthCreationComponent implements OnInit, AfterViewInit {
   }
 
   createNewMonth(newMonth: Month) {
+    this.creationLoader = true;
     this.monthsService
       .createMonth(newMonth)
+      .pipe(
+        finalize(() => {
+          this.creationLoader = false;
+        })
+      )
       .subscribe((month: MonthlyBudget) => {
+        this.toaster.success('Votre mois a bien été crée !');
         this.monthlyBudgetsStore.addMonth(month);
         this.backToHome();
       });

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -80,7 +80,7 @@ export class MonthCreationComponent implements OnInit, AfterViewInit {
             this.renderer.setStyle(
               this.addNewOutflowButton.nativeElement,
               'display',
-              'block'
+              'flex'
             );
           } else {
             this.renderer.setStyle(

--- a/front-v2/src/app/interceptors/http-requests.interceptor.ts
+++ b/front-v2/src/app/interceptors/http-requests.interceptor.ts
@@ -1,6 +1,15 @@
-import { HttpHeaders, HttpInterceptorFn } from '@angular/common/http';
+import {
+  HttpErrorResponse,
+  HttpHeaders,
+  HttpInterceptorFn,
+} from '@angular/common/http';
+import { inject } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+import { HotToastService } from '@ngxpert/hot-toast';
 
 export const httpRequestsInterceptor: HttpInterceptorFn = (req, next) => {
+  const toaster = inject(HotToastService);
+
   const headers = new HttpHeaders({
     Accept: 'application/json',
     'Content-Type': 'application/json',
@@ -11,5 +20,13 @@ export const httpRequestsInterceptor: HttpInterceptorFn = (req, next) => {
     headers,
   });
 
-  return next(newReq);
+  return next(newReq).pipe(
+    catchError((error: HttpErrorResponse) => {
+      const errorMessage = error.error.message || 'An unknown error occurred';
+
+      toaster.error(errorMessage);
+
+      return throwError(() => new Error(errorMessage));
+    })
+  );
 };

--- a/front-v2/src/app/pipes/date-normalize.pipe.spec.ts
+++ b/front-v2/src/app/pipes/date-normalize.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { DateNormalizePipe } from './date-normalize.pipe';
+
+describe('DateNormalizePipe', () => {
+  it('create an instance', () => {
+    const pipe = new DateNormalizePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/front-v2/src/app/pipes/date-normalize.pipe.ts
+++ b/front-v2/src/app/pipes/date-normalize.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'dateNormalize',
+  standalone: true,
+})
+export class DateNormalizePipe implements PipeTransform {
+  transform(value: string): unknown {
+    const event = new Date(value);
+    const options: Intl.DateTimeFormatOptions = {
+      month: 'long',
+      year: 'numeric',
+    };
+    return event.toLocaleDateString('fr-FR', options);
+  }
+}

--- a/front-v2/src/app/services/months/months.service.interface.ts
+++ b/front-v2/src/app/services/months/months.service.interface.ts
@@ -5,6 +5,7 @@ import { MonthlyBudget } from '../../models/monthlyBudget.model';
 
 export default interface MonthsServiceInterface {
   createMonth(month: Month): Observable<MonthlyBudget>;
+  getUnarchivedMonths(): Observable<MonthlyBudget[]>;
 }
 
 export const MONTHS_SERVICE = new InjectionToken<MonthsServiceInterface>(

--- a/front-v2/src/app/services/months/months.service.spec.ts
+++ b/front-v2/src/app/services/months/months.service.spec.ts
@@ -2,13 +2,23 @@ import { TestBed } from '@angular/core/testing';
 
 import { MonthsService } from './months.service';
 import { HttpClient, HttpHandler } from '@angular/common/http';
+import { MONTHLY_BUDGETS_STORE } from '../../stores/monthlyBudgets.store.interface';
 
 describe('MonthsService', () => {
   let service: MonthsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [HttpClient, HttpHandler],
+      providers: [
+        HttpClient,
+        HttpHandler,
+        {
+          provide: MONTHLY_BUDGETS_STORE,
+          useValue: {
+            addMonth: () => null,
+          },
+        },
+      ],
     });
     service = TestBed.inject(MonthsService);
   });

--- a/front-v2/src/app/stores/monthlyBudgets.store.interface.ts
+++ b/front-v2/src/app/stores/monthlyBudgets.store.interface.ts
@@ -7,6 +7,12 @@ export interface MonthlyBudgetsStoreInterface {
   addMonths(months: MonthlyBudget[]): void;
 
   getAll(): Signal<MonthlyBudget[]>;
+
+  getCurrent(): Signal<MonthlyBudget | null>;
+
+  setNextMonth(): Signal<MonthlyBudget | null>;
+
+  setPreviousMonth(): Signal<MonthlyBudget | null>;
 }
 
 export const MONTHLY_BUDGETS_STORE =

--- a/front-v2/src/app/stores/monthlyBudgets.store.interface.ts
+++ b/front-v2/src/app/stores/monthlyBudgets.store.interface.ts
@@ -4,6 +4,8 @@ import { MonthlyBudget } from '../models/monthlyBudget.model';
 export interface MonthlyBudgetsStoreInterface {
   addMonth(month: MonthlyBudget): void;
 
+  addMonths(months: MonthlyBudget[]): void;
+
   getAll(): Signal<MonthlyBudget[]>;
 }
 

--- a/front-v2/src/app/stores/monthlyBudgets.store.ts
+++ b/front-v2/src/app/stores/monthlyBudgets.store.ts
@@ -1,4 +1,4 @@
-import { Injectable, Signal, signal } from '@angular/core';
+import { effect, Injectable, Signal, signal } from '@angular/core';
 import { MonthlyBudgetsStoreInterface } from './monthlyBudgets.store.interface';
 import { MonthlyBudget } from '../models/monthlyBudget.model';
 
@@ -6,21 +6,68 @@ import { MonthlyBudget } from '../models/monthlyBudget.model';
   providedIn: 'root',
 })
 export class MonthlyBudgetsStore implements MonthlyBudgetsStoreInterface {
-  private _state = signal<MonthlyBudget[]>([]);
+  private _all = signal<MonthlyBudget[]>([]);
+  private _current = signal<MonthlyBudget | null>(null);
+
+  constructor() {
+    effect(
+      () => {
+        const allMonths = this._all();
+        if (allMonths.length > 0) {
+          this._current.set(allMonths[0]);
+        } else {
+          this._current.set(null);
+        }
+      },
+      { allowSignalWrites: true }
+    );
+  }
 
   addMonth(month: MonthlyBudget) {
-    this._state.update((months) => {
+    this._all.update((months) => {
       return [...months, month];
     });
   }
 
   addMonths(months: MonthlyBudget[]): void {
-    this._state.update(() => {
+    this._all.update(() => {
       return [...months];
     });
   }
 
   getAll(): Signal<MonthlyBudget[]> {
-    return this._state.asReadonly();
+    return this._all.asReadonly();
+  }
+
+  getCurrent(): Signal<MonthlyBudget | null> {
+    return this._current.asReadonly();
+  }
+
+  setNextMonth(): Signal<MonthlyBudget | null> {
+    const allMonths = this._all();
+    const currentMonth = this._current();
+
+    const currentIndex = allMonths.findIndex((month) => month === currentMonth);
+
+    if (currentIndex >= 0 && currentIndex < allMonths.length - 1) {
+      const nextMonth = allMonths[currentIndex + 1];
+      this._current.set(nextMonth);
+    }
+
+    return this.getCurrent();
+  }
+
+  setPreviousMonth(): Signal<MonthlyBudget | null> {
+    const allMonths = this._all();
+    const currentMonth = this._current();
+
+    const currentIndex = allMonths.findIndex((month) => month === currentMonth);
+
+    if (currentIndex > 0) {
+      const previousMonth = allMonths[currentIndex - 1];
+      this._current.set(previousMonth);
+    }
+
+    return this.getCurrent();
   }
 }

--- a/front-v2/src/app/stores/monthlyBudgets.store.ts
+++ b/front-v2/src/app/stores/monthlyBudgets.store.ts
@@ -14,6 +14,12 @@ export class MonthlyBudgetsStore implements MonthlyBudgetsStoreInterface {
     });
   }
 
+  addMonths(months: MonthlyBudget[]): void {
+    this._state.update(() => {
+      return [...months];
+    });
+  }
+
   getAll(): Signal<MonthlyBudget[]> {
     return this._state.asReadonly();
   }

--- a/front-v2/src/styles/_typo.scss
+++ b/front-v2/src/styles/_typo.scss
@@ -6,6 +6,10 @@
   font-size: var(--title-3);
   font-weight: bold;
 }
+%title-30 {
+  font-size: var(--title-30);
+  font-weight: bold;
+}
 %text-5 {
   font-size: var(--text-5);
 }

--- a/front-v2/src/styles/_typo.scss
+++ b/front-v2/src/styles/_typo.scss
@@ -6,6 +6,10 @@
   font-size: var(--title-3);
   font-weight: bold;
 }
+%title-20 {
+  font-size: var(--title-20);
+  font-weight: bold;
+}
 %title-30 {
   font-size: var(--title-30);
   font-weight: bold;

--- a/front-v2/src/styles/_variables.scss
+++ b/front-v2/src/styles/_variables.scss
@@ -25,4 +25,5 @@
   --text-5: 10px;
   --text-10: 15px;
   --title-3: 18px;
+  --title-30: 40px;
 }

--- a/front-v2/src/styles/_variables.scss
+++ b/front-v2/src/styles/_variables.scss
@@ -25,5 +25,6 @@
   --text-5: 10px;
   --text-10: 15px;
   --title-3: 18px;
+  --title-20: 35px;
   --title-30: 40px;
 }


### PR DESCRIPTION
## TODO

### Quand on vient de créer un mois

- [x] Header avec le premier mois du store, son solde courant et son prévisionnel

### Quand on arrive sur la home sans passer par la page de création de mois

- [x] Si le store est vide, récupérer tous les mois via `MonthsService`
    - [x] si l'API renvoi un tableau vide, on affiche le message qu'il n'y a aucun mois actuellement
- [x] Afficher le header
- [x] Afficher le loader pendant le temps de chargement

### Quand il y a plusieurs mois

- [x] Pouvoir naviguer d'un mois à l'autre via les flèches
- [x] Flèche de gauche disabled si on est sur le premier mois de la liste
- [x] Flèche de droite disabled si on est sur le dernier mois de la liste