### PR TITLE
[FRONT] Refonte de la modal des options

### DIFF
--- a/back/src/core/usecases/TransferBalanceIntoMonth.ts
+++ b/back/src/core/usecases/TransferBalanceIntoMonth.ts
@@ -25,14 +25,6 @@ export default class TransferBalanceIntoMonth {
     fromWeeklyBudgetId,
     toAccountId,
   }: TransferBalanceIntoMonthCommand): Promise<Month> {
-    console.info({
-      monthId,
-      amount,
-      fromAccountId,
-      toWeeklyBudgetId,
-      fromWeeklyBudgetId,
-      toAccountId,
-    });
     const month = await this.monthRepository.getTransferableById(monthId);
     if (!month) {
       throw new MonthNotFoundError();

--- a/front-v2/src/app/components/home/home.component.html
+++ b/front-v2/src/app/components/home/home.component.html
@@ -1,73 +1,132 @@
 <app-modal [modalOpen]="openMenuModal" (click)="toggleMenuModal($event)">
   @if(current) {
-  <button
-    class="menu-footer-add-links__link"
-    (click)="navigateToExpenses($event)"
-    type="button"
-  >
-    <i class="menu-footer-add-links-link__icon fa-solid fa-basket-shopping"></i>
-    <span class="menu-footer-add-links-link__label">Ajouter une dépense</span>
-  </button>
-  <button
-    class="menu-footer-add-links__link"
-    (click)="navigateToOutflows($event)"
-    type="button"
-  >
-    <i
-      class="menu-footer-add-links-link__icon fa-solid fa-money-bill-transfer"
-    ></i>
-    <span class="menu-footer-add-links-link__label"
-      >Ajouter une sortie mensuelle</span
-    >
-  </button>
-  <app-divider></app-divider>
-  <button
-    class="menu-footer-add-links__link menu-footer-add-links__link--danger"
-    type="button"
-    (click)="toggleArchiveCurrentMonthModal($event)"
-  >
-    @if(archiveLoading) {
-    <ng-container *ngTemplateOutlet="loader"></ng-container>
-    } @else {
-    <i class="menu-footer-add-links-link__icon fa-solid fa-box-archive"></i>
-    <span class="menu-footer-add-links-link__label"
-      >Archiver
-      <span class="menu-footer-add-links-link__label--capitalize">{{
-        currentMonthDate | dateNormalize
-      }}</span></span
-    >}
-  </button>
-  <app-divider></app-divider>
+  <div class="menu">
+    <div class="menu__category">
+      <div class="menu-category__title">
+        <i class="fa-solid fa-gear"></i>&nbsp;
+        <span>{{ currentMonthDate | dateNormalize }}</span>
+      </div>
+      <div class="menu-category__actions">
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-basket-shopping"
+            (click)="navigateToExpenses($event)"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Ajouter une dépense</span
+          >
+        </div>
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-money-bill-transfer"
+            (click)="navigateToOutflows($event)"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Ajouter une sortie mensuelle</span
+          >
+        </div>
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-box-archive"
+            [variant]="'danger'"
+            [loading]="archiveLoading"
+            (click)="toggleArchiveCurrentMonthModal($event)"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Archiver le mois</span
+          >
+        </div>
+      </div>
+    </div>
+    <app-divider></app-divider>
+    <div class="menu__category">
+      <div class="menu-category__title">
+        <i class="fa-solid fa-gear"></i>&nbsp;
+        <span>Tous les mois</span>
+      </div>
+      <div class="menu-category__actions">
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-calendar-plus"
+            [variant]="'danger'"
+            (click)="navigateToMonthCreation()"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Créer un nouveau mois</span
+          >
+        </div>
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-box-archive"
+            (click)="navigateToArchivedMonths($event)"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Accéder aux mois archivés</span
+          >
+        </div>
+        <div class="menu-category-actions__action">
+          <app-button-icon icon="fa-shapes" [disabled]="true"></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Gérer les templates</span
+          >
+        </div>
+      </div>
+    </div>
+    <app-divider></app-divider>
+    <div class="menu__category">
+      <div class="menu-category__title">
+        <i class="fa-solid fa-gear"></i>&nbsp;
+        <span>Gestion Générale</span>
+      </div>
+      <div class="menu-category__actions">
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-calendar-days"
+            [disabled]="true"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Sorties annuelles</span
+          >
+        </div>
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-piggy-bank"
+            [disabled]="true"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label">Économies</span>
+        </div>
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-file-invoice-dollar"
+            [disabled]="true"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Remboursements</span
+          >
+        </div>
+      </div>
+    </div>
+    <app-divider></app-divider>
+    <div class="menu__category">
+      <div class="menu-category__title">
+        <i class="fa-solid fa-gear"></i>&nbsp;
+        <span>Settings</span>
+      </div>
+      <div class="menu-category__actions">
+        <div class="menu-category-actions__action">
+          <app-button-icon
+            icon="fa-right-from-bracket"
+            [variant]="'danger'"
+            (click)="logout($event)"
+          ></app-button-icon>
+          <span class="menu-category-actions-action__label"
+            >Se déconnecter</span
+          >
+        </div>
+      </div>
+    </div>
+  </div>
   }
-  <button
-    class="menu-footer-add-links__link"
-    (click)="navigateToMonthCreation()"
-    type="button"
-  >
-    <i class="menu-footer-add-links-link__icon fa-solid fa-calendar-plus"></i>
-    <span class="menu-footer-add-links-link__label">Créer un nouveau mois</span>
-  </button>
-  <button
-    class="menu-footer-add-links__link"
-    type="button"
-    (click)="navigateToArchivedMonths($event)"
-  >
-    <i class="menu-footer-add-links-link__icon fa-solid fa-box-archive"></i>
-    <span class="menu-footer-add-links-link__label"
-      >Accéder aux mois archivés</span
-    >
-  </button>
-  <app-divider></app-divider>
-  <button
-    class="menu-footer-add-links__link menu-footer-add-links__link--danger"
-    type="button"
-    (click)="logout($event)"
-  >
-    <i
-      class="menu-footer-add-links-link__icon fa-solid fa-right-from-bracket"
-    ></i>
-    <span class="menu-footer-add-links-link__label">Se déconnecter</span>
-  </button>
 </app-modal>
 <app-modal
   [modalOpen]="confirmArchiveModalIsOpen"

--- a/front-v2/src/app/components/home/home.component.scss
+++ b/front-v2/src/app/components/home/home.component.scss
@@ -227,3 +227,52 @@
     transform: rotate(60deg);
   }
 }
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &__category {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
+.menu-category {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &__actions {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    justify-content: space-between;
+  }
+
+  &__title {
+    @extend %title-3;
+    text-transform: capitalize;
+  }
+}
+
+.menu-category-actions {
+  &__action {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    width: 30%;
+  }
+}
+
+.menu-category-actions-action {
+  &__label {
+    @extend %text-5;
+
+    width: 70%;
+    text-align: center;
+  }
+}

--- a/front-v2/src/app/design-system/button-icon/button-icon.component.html
+++ b/front-v2/src/app/design-system/button-icon/button-icon.component.html
@@ -1,0 +1,67 @@
+<button
+  [class]="className"
+  [disabled]="disabled() || loading()"
+  type="button"
+  (click)="onClick($event)"
+>
+  @if (loading()) {
+  <ng-container *ngTemplateOutlet="loader"></ng-container>
+  } @else {
+  <i class="fa-solid {{ icon() }}"></i>
+  }
+</button>
+
+<ng-template #loader>
+  <span class="icon__loader">
+    <svg
+      width="50"
+      height="50"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <style>
+        .spinner_nOfF {
+          animation: spinner_qtyZ 2s cubic-bezier(0.36, 0.6, 0.31, 1) infinite;
+          fill: currentColor;
+        }
+        .spinner_fVhf {
+          animation-delay: -0.5s;
+          fill: currentColor;
+        }
+        .spinner_piVe {
+          animation-delay: -1s;
+          fill: currentColor;
+        }
+        .spinner_MSNs {
+          animation-delay: -1.5s;
+          fill: currentColor;
+        }
+        @keyframes spinner_qtyZ {
+          0% {
+            r: 0;
+          }
+          25% {
+            r: 3px;
+            cx: 4px;
+          }
+          50% {
+            r: 3px;
+            cx: 12px;
+          }
+          75% {
+            r: 3px;
+            cx: 20px;
+          }
+          100% {
+            r: 0;
+            cx: 20px;
+          }
+        }
+      </style>
+      <circle class="spinner_nOfF" cx="4" cy="12" r="3" />
+      <circle class="spinner_nOfF spinner_fVhf" cx="4" cy="12" r="3" />
+      <circle class="spinner_nOfF spinner_piVe" cx="4" cy="12" r="3" />
+      <circle class="spinner_nOfF spinner_MSNs" cx="4" cy="12" r="3" />
+    </svg>
+  </span>
+</ng-template>

--- a/front-v2/src/app/design-system/button-icon/button-icon.component.scss
+++ b/front-v2/src/app/design-system/button-icon/button-icon.component.scss
@@ -1,0 +1,36 @@
+@import "../../../styles/variables";
+
+.icon {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+
+    border: 0;
+    background: none;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    background-color: var(--color-950);
+    border-radius: 50%;
+    padding: 10px;
+    font-size: 25px;
+    height: 45px;
+    width: 45px;
+    box-sizing: border-box;
+
+    &:disabled {
+        opacity: 0.5;
+    }
+
+    &--default {
+        background-color: var(--color-800);
+    }
+
+    &--danger {
+    background-color: var(--color-950);
+    }
+
+    &__loader {
+        color: var(--color-50);
+    }
+}

--- a/front-v2/src/app/design-system/button-icon/button-icon.component.spec.ts
+++ b/front-v2/src/app/design-system/button-icon/button-icon.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonIconComponent } from './button-icon.component';
+import { DesignSystemModule } from '../design-system.module';
+
+describe('ButtonIconComponent', () => {
+  let component: ButtonIconComponent;
+  let fixture: ComponentFixture<ButtonIconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ButtonIconComponent],
+      imports: [DesignSystemModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-v2/src/app/design-system/button-icon/button-icon.component.ts
+++ b/front-v2/src/app/design-system/button-icon/button-icon.component.ts
@@ -1,0 +1,23 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-button-icon',
+  standalone: false,
+  templateUrl: './button-icon.component.html',
+  styleUrl: './button-icon.component.scss',
+})
+export class ButtonIconComponent {
+  icon = input<string | null>(null);
+  variant = input<'default' | 'danger'>('default');
+  loading = input(false);
+  disabled = input(false);
+  click = output<Event>();
+
+  get className() {
+    return `icon icon--${this.variant()}`;
+  }
+
+  onClick(event: Event) {
+    this.click.emit(event);
+  }
+}

--- a/front-v2/src/app/design-system/design-system.module.ts
+++ b/front-v2/src/app/design-system/design-system.module.ts
@@ -14,6 +14,7 @@ import { ProgressBarComponent } from './progress-bar/progress-bar.component';
 import { ModalComponent } from './modal/modal/modal.component';
 import { InfoComponent } from './info/info.component';
 import { NumpadComponent } from './numpad/numpad.component';
+import { ButtonIconComponent } from './button-icon/button-icon.component';
 
 @NgModule({
   declarations: [
@@ -30,6 +31,7 @@ import { NumpadComponent } from './numpad/numpad.component';
     ModalComponent,
     InfoComponent,
     NumpadComponent,
+    ButtonIconComponent,
   ],
   imports: [CommonModule, ReactiveFormsModule],
   exports: [
@@ -46,6 +48,7 @@ import { NumpadComponent } from './numpad/numpad.component';
     ModalComponent,
     InfoComponent,
     NumpadComponent,
+    ButtonIconComponent,
   ],
 })
 export class DesignSystemModule {}


### PR DESCRIPTION
Transformer mes options en une plus grande modal avec une x pour la fermer.

C'est une grille d'icônes avec un petit libellé.

On y trouve donc :

`<i class="fa-solid fa-gear"></i>`

**Gestion du mois d'Octobre 2024**

- Ajouter une dépense
- Ajouter une sortie
- Archiver Octobre 2024

**Gestion des mois**

- Créer un nouveau mois
- Accéder aux mois archivés 
- Templates (disabled) `<i class="fa-solid fa-shapes"></i>`

**Général**

- Sorties annuelles (disabled) `<i class="fa-solid fa-calendar-days"></i>`
- Économies (disabled) `<i class="fa-solid fa-piggy-bank"></i>`
- Remboursements (disabled) `<i class="fa-solid fa-file-invoice-dollar"></i>`

**Settings**

- Se déconnecter  

#102 