### PR TITLE
[UX] Création de mois : Simuler la suppression d'une sortie mensuelle

### DIFF
--- a/front-v2/src/app/components/month-creation/month-creation.component.html
+++ b/front-v2/src/app/components/month-creation/month-creation.component.html
@@ -111,6 +111,10 @@
           >
         </div>
 
+        <app-toggle-visibility-button
+          [index]="i"
+          (clicked)="toggleVisibilityForOutflowWithIndex(i)"
+        ></app-toggle-visibility-button>
         <button
           class="month-creation-item__edit"
           type="button"

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -26,11 +26,17 @@ import { finalize } from 'rxjs';
 import ToasterServiceInterface, {
   TOASTER_SERVICE,
 } from '../../services/toaster.service.interface';
+import { ToggleVisibilityButtonComponent } from './toggle-visibility-button/toggle-visibility-button.component';
 
 @Component({
   selector: 'app-month-creation',
   standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, DesignSystemModule],
+  imports: [
+    ReactiveFormsModule,
+    CommonModule,
+    DesignSystemModule,
+    ToggleVisibilityButtonComponent,
+  ],
   templateUrl: './month-creation.component.html',
   styleUrl: './month-creation.component.scss',
 })
@@ -47,6 +53,7 @@ export class MonthCreationComponent implements OnInit {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   amountValueControl: AbstractControl<any, any> | null = null;
   takeIntoAccountPendingDebits = true;
+  outflowsRemovedFromForecastBalance: number[] = [];
 
   newMonth: Month = {
     month: new Date(),
@@ -86,6 +93,15 @@ export class MonthCreationComponent implements OnInit {
   togglePendingDebits(event: Event) {
     this.takeIntoAccountPendingDebits = !this.takeIntoAccountPendingDebits;
     event.preventDefault();
+  }
+
+  toggleVisibilityForOutflowWithIndex(index: number) {
+    if (this.outflowsRemovedFromForecastBalance.includes(index)) {
+      this.outflowsRemovedFromForecastBalance =
+        this.outflowsRemovedFromForecastBalance.filter((i) => i !== index);
+    } else {
+      this.outflowsRemovedFromForecastBalance.push(index);
+    }
   }
 
   private setForm() {
@@ -130,7 +146,12 @@ export class MonthCreationComponent implements OnInit {
   }
 
   get forecastBalance() {
-    const totalOutflows = (this.form.value as Month).outflows.reduce(
+    const outflowsTakenIntoAccount = (this.form.value as Month).outflows.filter(
+      (_outflow, i) => {
+        return !this.outflowsRemovedFromForecastBalance.includes(i);
+      }
+    );
+    const totalOutflows = outflowsTakenIntoAccount.reduce(
       (total, { amount }) => {
         return total + amount;
       },

--- a/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.html
+++ b/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.html
@@ -1,0 +1,12 @@
+<button
+  class="toggle_visibility"
+  [ngClass]="{ 'toggle_visibility--closed': open === false }"
+  type="button"
+  (click)="toggle()"
+>
+  @if(open === true) {
+  <i class="fa-solid fa-eye-slash"></i>
+  } @else {
+  <i class="fa-solid fa-eye"></i>
+  }
+</button>

--- a/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.scss
+++ b/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.scss
@@ -1,0 +1,19 @@
+@import "../../../../styles/variables";
+
+.toggle_visibility {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 10px;
+    height: 10px;
+    padding: 20px;
+    border-radius: 50%;
+    background: var(--color-100);
+    font-size: 20px;
+    color: var(--color-900);
+    border: 3px solid var(--color-900);
+
+    &--closed {
+        opacity: 0.5;
+    }
+}

--- a/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.spec.ts
+++ b/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ToggleVisibilityButtonComponent } from './toggle-visibility-button.component';
+
+describe('ToggleVisibilityButtonComponent', () => {
+  let component: ToggleVisibilityButtonComponent;
+  let fixture: ComponentFixture<ToggleVisibilityButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ToggleVisibilityButtonComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ToggleVisibilityButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.ts
+++ b/front-v2/src/app/components/month-creation/toggle-visibility-button/toggle-visibility-button.component.ts
@@ -1,0 +1,20 @@
+import { NgClass } from '@angular/common';
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-toggle-visibility-button',
+  standalone: true,
+  imports: [NgClass],
+  templateUrl: './toggle-visibility-button.component.html',
+  styleUrl: './toggle-visibility-button.component.scss',
+})
+export class ToggleVisibilityButtonComponent {
+  index = input.required<number>();
+  clicked = output<number>();
+  open = true;
+
+  toggle() {
+    this.open = !this.open;
+    this.clicked.emit(this.index());
+  }
+}


### PR DESCRIPTION
Dans la création de mois : pouvoir "cacher" une sortie mensuelle pour voir ce que ça ferait de la supprimer.
```html
<i class="fa-solid fa-eye"></i>
<i class="fa-solid fa-eye-slash"></i>
```

#55 