### PR TITLE
[UX] Page expenses : Quick Win

### DIFF
--- a/front-v2/src/app/components/expenses/expenses.component.html
+++ b/front-v2/src/app/components/expenses/expenses.component.html
@@ -27,23 +27,24 @@
           }}</span>
         </div>
         <div class="expenses-list__filters">
-          <ng-container *ngFor="let week of weekButtons">
-            <button
-              (click)="updateFilterState(week)"
-              [ngClass]="{
-                'expenses-list-filters__filter--active': filterIsActive(week)
-              }"
-              type="button"
-              class="expenses-list-filters__filter"
-            >
-              <span>{{ week }}</span>
-            </button>
-          </ng-container>
+          <a href="#" (click)="toggleBudgetsUnfolded($event)">{{
+            unfoldBudgetsLabel
+          }}</a>
         </div>
       </div>
       <ng-container *ngFor="let week of weeks; let i = index">
         <div class="expenses-list__week">
           <div class="expenses-list__week__header">
+            <button
+              class="expenses-list__week-hide"
+              [ngClass]="{
+                'expenses-list__week-hide--folded': !filterIsActive(i + 1)
+              }"
+              type="button"
+              (click)="updateFilterState(i + 1)"
+            >
+              <i class="fa-solid fa-chevron-right"></i>
+            </button>
             <h2 class="expenses-list__week-name">
               {{ week.name }}
             </h2>
@@ -55,20 +56,6 @@
               <i class="fa-solid fa-plus"></i>
             </button>
             <button
-              class="expenses-list__week-hide"
-              [ngClass]="{
-                'expenses-list__week-hide--hidden': !filterIsActive(i + 1)
-              }"
-              type="button"
-              (click)="updateFilterState(i + 1)"
-            >
-              @if(!filterIsActive(i + 1)) {
-              <i class="fa-solid fa-eye"></i>
-              } @else {
-              <i class="fa-solid fa-eye-slash"></i>
-              }
-            </button>
-            <button
               class="expenses-list__week-transfer"
               type="button"
               (click)="openTransferChoiceModal(week, $event)"
@@ -76,6 +63,8 @@
               <i class="fa-solid fa-right-left"></i>
             </button>
           </div>
+
+          <div class="expenses-list__infos">{{ geBudgetsInfos(week.id) }}</div>
           <div class="expenses-list__balance">
             <span>Solde :</span>
             <app-progress-bar
@@ -83,7 +72,8 @@
               [total]="getInitialBalanceByWeekName(week.name)"
             ></app-progress-bar>
           </div>
-          @if (getExpensesFormGroupByWeekId(week.id).length === 0) {
+          @if (getExpensesFormGroupByWeekId(week.id).length === 0 &&
+          filterIsActive(i + 1)) {
           <app-info>Pas de dépenses à afficher 😁</app-info> } @else {
           <app-item
             *ngFor="

--- a/front-v2/src/app/components/expenses/expenses.component.scss
+++ b/front-v2/src/app/components/expenses/expenses.component.scss
@@ -39,11 +39,18 @@
       display: flex;
       flex-direction: row;
       gap: 10px;
+      padding-left: 10px;
     }
 
     &-hide {
-      &--hidden {
-        opacity: 0.5;
+      .fa-chevron-right {
+        transform: rotate(90deg);
+        transition: transform 0.3s ease;
+      }
+      &--folded {
+        .fa-chevron-right {
+          transform: rotate(0deg);
+        }
       }
     }
 
@@ -67,8 +74,21 @@
       width: 30px;
       box-sizing: border-box;
     }
+    &-hide {
+      color: var(--color-800);
+      background-color: transparent;
+      padding: 0;
+      gap: 0;
+      width: 0px;
+      border-radius: 0;
+    }
   }
 
+  &__infos {
+    @extend %text-5;
+
+    font-weight: bold;
+  }
 
   &__balance {
     display: flex;

--- a/front-v2/src/app/components/expenses/expenses.component.ts
+++ b/front-v2/src/app/components/expenses/expenses.component.ts
@@ -74,6 +74,8 @@ export class ExpensesComponent implements AfterViewInit {
   fromWeeklyBudgetTransfer: WeeklyBudget | null = null;
   transferIsLoading = false;
 
+  budgetsUnfolded = false;
+
   constructor(
     private fb: FormBuilder,
     private injector: Injector,
@@ -137,8 +139,27 @@ export class ExpensesComponent implements AfterViewInit {
     );
   }
 
-  get weekButtons() {
-    return [1, 2, 3, 4, 5];
+  get unfoldBudgetsLabel() {
+    return this.budgetsUnfolded ? 'Tout replier' : 'Tout déplier';
+  }
+
+  geBudgetsInfos(weekId: string) {
+    const expensesForWeekId = this.getExpensesByWeekId(weekId);
+    const totalExpenses = expensesForWeekId.length;
+    const checkedExpenses = expensesForWeekId.filter(
+      (e) => !e.isChecked
+    ).length;
+    return `${checkedExpenses} non-prélevées / ${totalExpenses}`;
+  }
+
+  toggleBudgetsUnfolded(event: Event) {
+    event.preventDefault();
+    this.budgetsUnfolded = !this.budgetsUnfolded;
+    if (this.budgetsUnfolded) {
+      this.filters = [1, 2, 3, 4, 5];
+    } else {
+      this.filters = [];
+    }
   }
 
   openExpenseDelationModal(expense: AbstractControl<Expense>, event: Event) {
@@ -184,6 +205,8 @@ export class ExpensesComponent implements AfterViewInit {
       });
 
       this.expenses()!.forEach((expense) => this.addExpense(expense));
+
+      this.filters = [];
     }
   }
 
@@ -221,6 +244,16 @@ export class ExpensesComponent implements AfterViewInit {
       }
       return expenseWeekId === weekId && this.filters.includes(weekNumber + 1);
     });
+  }
+
+  getExpensesByWeekId(weekId: string) {
+    const budget = this.month()!.account.weeklyBudgets.find(
+      (w) => w.id === weekId
+    );
+    if (budget) {
+      return budget.expenses;
+    }
+    return [];
   }
 
   setAddExpenseForm(weekId?: string) {


### PR DESCRIPTION
Sur la page `/expenses`

Retirer les filtres 1, 2, 3, 4, 5
Les remplacer par un lien toggle : "Déplier tous les budgets" / "Replier tous les budgets"
Ils sont tous repliés par défaut

Par défaut on voit:
- Une flèche pour déplier / replier (avec une animation ?)
- Le nom
- Les boutons
- La progression des dépenses
- "n dépenses prélevées sur n"