### PR TITLE
 [UX] Création d'un mois : Permettre de supprimer une sortie annuelle

### DIFF
--- a/front-v2/src/app/components/month-creation/month-creation.component.html
+++ b/front-v2/src/app/components/month-creation/month-creation.component.html
@@ -1,6 +1,6 @@
 <app-modal
-  [modalOpen]="outflowDelationModalIsOpen"
-  (click)="closeOutflowDelationModal($event)"
+  [modalOpen]="yearlyOutflowDelationModalIsOpen"
+  (click)="closeYearlyOutflowDelationModal($event)"
 >
   <app-button
     [size]="'big'"
@@ -8,6 +8,18 @@
     [label]="'Supprimer la sortie définitivement'"
     [loading]="removeIsLoading"
     (click)="removeYearlyOutflow($event)"
+  ></app-button>
+</app-modal>
+<app-modal
+  [modalOpen]="pendingDebitDelationModalIsOpen"
+  (click)="closePendingDebitDelationModal($event)"
+>
+  <app-button
+    [size]="'big'"
+    [variant]="'danger'"
+    [label]="'Supprimer la sortie définitivement'"
+    [loading]="removeIsLoading"
+    (click)="removePendingDebit($event)"
   ></app-button>
 </app-modal>
 @if(!dataLoaded) {
@@ -93,7 +105,7 @@
         <button
           class="month-creation-item__delete"
           type="button"
-          (click)="openOutflowDelationModal(i, $event)"
+          (click)="openYearlyOutflowDelationModal(i, $event)"
         >
           <i class="fa-solid fa-trash-can"></i>
         </button>
@@ -145,6 +157,13 @@
             >{{ debit.get("amount")?.value }}€</span
           >
         </div>
+        <button
+          class="month-creation-item__delete"
+          type="button"
+          (click)="openPendingDebitDelationModal(i, $event)"
+        >
+          <i class="fa-solid fa-trash-can"></i>
+        </button>
       </div>
     </app-item>
     }

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -59,10 +59,12 @@ export class MonthCreationComponent implements OnInit {
   amountValueControl: AbstractControl<any, any> | null = null;
   takeIntoAccountPendingDebits = true;
   outflowsRemovedFromForecastBalance: number[] = [];
-  outflowDelationModalIsOpen = false;
+  yearlyOutflowDelationModalIsOpen = false;
+  pendingDebitDelationModalIsOpen = false;
   outflowToDelete: AbstractControl<YearlyOutflow> | null = null;
   removeIsLoading = false;
   selectedYearlyOutflowIndex: number | null = null;
+  selectedPendingDebitIndex: number | null = null;
 
   newMonth: Month = {
     month: new Date(),
@@ -341,14 +343,14 @@ export class MonthCreationComponent implements OnInit {
     return this.outflows.at(this.selectedOutflowIndex!) as FormGroup;
   }
 
-  openOutflowDelationModal(index: number, event: Event) {
-    this.outflowDelationModalIsOpen = true;
+  openYearlyOutflowDelationModal(index: number, event: Event) {
+    this.yearlyOutflowDelationModalIsOpen = true;
     this.selectedYearlyOutflowIndex = index;
     event.stopPropagation();
   }
 
-  closeOutflowDelationModal(event: Event) {
-    this.outflowDelationModalIsOpen = false;
+  closeYearlyOutflowDelationModal(event: Event) {
+    this.yearlyOutflowDelationModalIsOpen = false;
     this.selectedYearlyOutflowIndex = null;
     event.stopPropagation();
   }
@@ -356,7 +358,27 @@ export class MonthCreationComponent implements OnInit {
   removeYearlyOutflow(event: Event) {
     if (this.selectedYearlyOutflowIndex !== null) {
       this.yearlyOutflowsControls.removeAt(this.selectedYearlyOutflowIndex);
-      this.closeOutflowDelationModal(event);
+      this.closeYearlyOutflowDelationModal(event);
+    }
+    event.stopPropagation();
+  }
+
+  openPendingDebitDelationModal(index: number, event: Event) {
+    this.pendingDebitDelationModalIsOpen = true;
+    this.selectedPendingDebitIndex = index;
+    event.stopPropagation();
+  }
+
+  closePendingDebitDelationModal(event: Event) {
+    this.pendingDebitDelationModalIsOpen = false;
+    this.selectedPendingDebitIndex = null;
+    event.stopPropagation();
+  }
+
+  removePendingDebit(event: Event) {
+    if (this.selectedPendingDebitIndex !== null) {
+      this.pendingDebits.removeAt(this.selectedPendingDebitIndex);
+      this.closePendingDebitDelationModal(event);
     }
     event.stopPropagation();
   }


### PR DESCRIPTION
Pendant la création d'un mois, on peut supprimer des items dans les dépenses en attente

#143 