### PR TITLE
Création de mois — gestion des pending budgets

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -19,7 +19,8 @@
         "pg": "^8.13.1",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.20",
-        "uuid": "^11.0.3"
+        "uuid": "^11.0.3",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.4",
@@ -4398,6 +4399,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -7337,6 +7347,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="
     }
   }
 }

--- a/back/package.json
+++ b/back/package.json
@@ -46,7 +46,8 @@
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.20",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",

--- a/back/src/consumers/api/deserializers/monthCreation.ts
+++ b/back/src/consumers/api/deserializers/monthCreation.ts
@@ -4,9 +4,6 @@ import MonthCreationCommand, {
 } from "../../../core/commands/MonthCreationCommand.js";
 import Koi from "../validators/Koi.js";
 import SerializationError from "../errors/DeserializationError.js";
-import PendingDebit, {
-  PendingDebitProps,
-} from "../../../core/models/pending-debit/PendingDebit.js";
 
 export type MonthCreationDeserializer = (body: any) => MonthCreationCommand;
 
@@ -16,7 +13,6 @@ const deserializer: MonthCreationDeserializer = (body: any) => {
     Koi.validate(body.startingBalance).number();
     Koi.validate(body.outflows).array().notEmpty();
     Koi.validate(body.weeklyBudgets).array().notEmpty();
-    Koi.validate(body.pendingDebits).array();
     body.outflows.forEach((outflow: OutflowCreationCommand) => {
       Koi.validate(outflow.amount).number();
       Koi.validate(outflow.label).string().notEmpty();
@@ -24,14 +20,6 @@ const deserializer: MonthCreationDeserializer = (body: any) => {
     body.weeklyBudgets.forEach((weeklyBudget: BudgetCreationCommand) => {
       Koi.validate(weeklyBudget.initialBalance).number();
       Koi.validate(weeklyBudget.name).string().notEmpty();
-    });
-    body.pendingDebits.forEach((pendingDebit: PendingDebit) => {
-      Koi.validate(pendingDebit.id).uuid();
-      Koi.validate(pendingDebit.monthId).uuid();
-      Koi.validate(pendingDebit.monthDate).date();
-      Koi.validate(pendingDebit.type).oneOf("outflow", "expense");
-      Koi.validate(pendingDebit.amount).number();
-      Koi.validate(pendingDebit.label).string().notEmpty();
     });
   } catch (e: any) {
     throw new SerializationError("monthCreation", e.message);
@@ -48,16 +36,6 @@ const deserializer: MonthCreationDeserializer = (body: any) => {
       (weeklyBudget: BudgetCreationCommand) => ({
         name: weeklyBudget.name,
         initialBalance: weeklyBudget.initialBalance,
-      })
-    ),
-    pendingDebits: body.pendingDebits.map(
-      (pendingDebit: PendingDebitProps) => ({
-        id: pendingDebit.id,
-        monthId: pendingDebit.monthId,
-        monthDate: pendingDebit.monthDate,
-        label: pendingDebit.label,
-        amount: pendingDebit.amount,
-        type: pendingDebit.type,
       })
     ),
   };

--- a/back/src/consumers/api/deserializers/monthCreation.ts
+++ b/back/src/consumers/api/deserializers/monthCreation.ts
@@ -2,40 +2,25 @@ import MonthCreationCommand, {
   OutflowCreationCommand,
   BudgetCreationCommand,
 } from "../../../core/commands/MonthCreationCommand.js";
-import Koi from "../validators/Koi.js";
-import SerializationError from "../errors/DeserializationError.js";
+import { monthCreationSchema, validSchema } from "../schemas.js";
 
 export type MonthCreationDeserializer = (body: any) => MonthCreationCommand;
 
 const deserializer: MonthCreationDeserializer = (body: any) => {
-  try {
-    Koi.validate(body.month).date();
-    Koi.validate(body.startingBalance).number();
-    Koi.validate(body.outflows).array().notEmpty();
-    Koi.validate(body.weeklyBudgets).array().notEmpty();
-    body.outflows.forEach((outflow: OutflowCreationCommand) => {
-      Koi.validate(outflow.amount).number();
-      Koi.validate(outflow.label).string().notEmpty();
-    });
-    body.weeklyBudgets.forEach((weeklyBudget: BudgetCreationCommand) => {
-      Koi.validate(weeklyBudget.initialBalance).number();
-      Koi.validate(weeklyBudget.name).string().notEmpty();
-    });
-  } catch (e: any) {
-    throw new SerializationError("monthCreation", e.message);
-  }
+  const data = validSchema(monthCreationSchema, body);
 
   return {
-    date: body.month,
-    initialBalance: body.startingBalance,
-    outflows: body.outflows.map((outflow: OutflowCreationCommand) => ({
+    date: data.month,
+    initialBalance: data.startingBalance,
+    outflows: data.outflows.map((outflow: OutflowCreationCommand) => ({
       label: outflow.label,
       amount: outflow.amount,
     })),
-    weeklyBudgets: body.weeklyBudgets.map(
+    weeklyBudgets: data.weeklyBudgets.map(
       (weeklyBudget: BudgetCreationCommand) => ({
         name: weeklyBudget.name,
         initialBalance: weeklyBudget.initialBalance,
+        expenses: weeklyBudget.expenses,
       })
     ),
   };

--- a/back/src/consumers/api/errorHandler.ts
+++ b/back/src/consumers/api/errorHandler.ts
@@ -10,7 +10,7 @@ const errorHandler = (
   switch (error.name) {
     /** @deprecated */
     case "UpdateExpenseCommandError":
-    case "DeserializationError":
+    case "RequestValidationError":
       statusCode = 400;
       break;
     case "MonthNotFoundError":
@@ -24,7 +24,6 @@ const errorHandler = (
       statusCode = 404;
       break;
     case "AccountInitialBalanceError":
-    case "WeeklyBudgetInitialBalanceError":
     case "WeeklyExpenseAmountError":
     case "TransferBalanceIntoMonthError":
     case "YearlySavingsAddError":

--- a/back/src/consumers/api/errors/DeserializationError.ts
+++ b/back/src/consumers/api/errors/DeserializationError.ts
@@ -1,6 +1,6 @@
-export default class DeserializationError extends Error {
+export default class RequestValidationError extends Error {
   constructor(serializer: string, message: string) {
     super(`${serializer}: ${message}`);
-    this.name = "DeserializationError";
+    this.name = "RequestValidationError";
   }
 }

--- a/back/src/consumers/api/schemas.ts
+++ b/back/src/consumers/api/schemas.ts
@@ -1,0 +1,58 @@
+import { z, ZodSchema } from "zod";
+import RequestValidationError from "./errors/DeserializationError.js";
+import _ from "lodash";
+
+function validSchema<T extends ZodSchema>(
+  schema: T,
+  data: unknown
+): z.infer<T> {
+  const parsedData = schema.safeParse(data);
+  if (!parsedData.success) {
+    const [firstError] = parsedData.error.errors;
+    throw new RequestValidationError("", firstError.message);
+  }
+
+  return parsedData.data;
+}
+
+const _dateSchema = (message: string) =>
+  z
+    .string()
+    .refine(
+      (val) =>
+        _.isDate(new Date(val)) && new Date(val).toString() !== "Invalid Date",
+      { message }
+    );
+
+const dateSchema = (message: string) =>
+  _dateSchema(message).transform((val) => new Date(val));
+
+const outflowCreationSchema = z.object({
+  label: z.string({ message: "Outflow: Le label est obligatoire" }),
+  amount: z.number({ message: "Outflow: Le montant est obligatoire" }),
+});
+
+const expenseCreationSchema = z.object({
+  label: z.string({ message: "Expense: Le label est obligatoire" }),
+  amount: z.number({ message: "Expense: Le montant est obligatoire" }),
+  date: dateSchema("Expense: La date est obligatoire"),
+});
+
+const budgetCreationSchema = z.object({
+  name: z.string({ message: "Budget: Le nom est obligatoire" }),
+  initialBalance: z.number({
+    message: "Budget: Le solde initial est obligatoire",
+  }),
+  expenses: z.array(expenseCreationSchema).default([]).optional(),
+});
+
+const monthCreationSchema = z.object({
+  month: dateSchema("Month: La date est obligatoire"),
+  startingBalance: z.number({
+    message: "Month: Le solde initial est obligatoire",
+  }),
+  outflows: z.array(outflowCreationSchema).default([]),
+  weeklyBudgets: z.array(budgetCreationSchema).default([]),
+});
+
+export { validSchema, monthCreationSchema };

--- a/back/src/core/commands/MonthCreationCommand.ts
+++ b/back/src/core/commands/MonthCreationCommand.ts
@@ -1,3 +1,5 @@
+import WeeklyExpense from "../models/month/account/WeeklyExpense.js";
+
 export type OutflowCreationCommand = {
   label: string;
   amount: number;
@@ -5,6 +7,7 @@ export type OutflowCreationCommand = {
 export type BudgetCreationCommand = {
   name: string;
   initialBalance: number;
+  expenses?: WeeklyExpense[];
 };
 interface MonthCreationCommand {
   date: Date;

--- a/back/src/core/commands/MonthCreationCommand.ts
+++ b/back/src/core/commands/MonthCreationCommand.ts
@@ -1,5 +1,3 @@
-import { PendingDebitProps } from "../models/pending-debit/PendingDebit.js";
-
 export type OutflowCreationCommand = {
   label: string;
   amount: number;
@@ -13,7 +11,6 @@ interface MonthCreationCommand {
   initialBalance: number;
   outflows: OutflowCreationCommand[];
   weeklyBudgets: BudgetCreationCommand[];
-  pendingDebits: PendingDebitProps[];
 }
 
 export default MonthCreationCommand;

--- a/back/src/core/errors/WeeklyBudgetErrors.ts
+++ b/back/src/core/errors/WeeklyBudgetErrors.ts
@@ -1,10 +1,3 @@
-class WeeklyBudgetInitialBalanceError extends Error {
-  constructor() {
-    super("WeeklyBudget: initial balance should be greater than 0");
-    this.name = "WeeklyBudgetInitialBalanceError";
-  }
-}
-
 class WeeklyBudgetNotFoundError extends Error {
   constructor() {
     super("WeeklyBudget: not found");
@@ -19,8 +12,4 @@ class AccountBudgetNameCantBeEmptyError extends Error {
   }
 }
 
-export {
-  WeeklyBudgetInitialBalanceError,
-  WeeklyBudgetNotFoundError,
-  AccountBudgetNameCantBeEmptyError,
-};
+export { WeeklyBudgetNotFoundError, AccountBudgetNameCantBeEmptyError };

--- a/back/src/core/factories/MonthFactory.ts
+++ b/back/src/core/factories/MonthFactory.ts
@@ -5,6 +5,7 @@ import AccountOutflow from "../models/month/account/AccountOutflow.js";
 import WeeklyBudget from "../models/month/account/WeeklyBudget.js";
 import { AccountInitialBalanceError } from "../errors/AccountErrors.js";
 import IdProvider from "../ports/providers/IdProvider.js";
+import WeeklyExpense from "../models/month/account/WeeklyExpense.js";
 
 export default class MonthFactory {
   constructor(public readonly idProvider: IdProvider) {}
@@ -28,6 +29,17 @@ export default class MonthFactory {
           id: this.idProvider.get(),
           initialBalance: weeklyBudget.initialBalance,
           name: weeklyBudget.name,
+          expenses:
+            weeklyBudget.expenses?.map(
+              (expense) =>
+                new WeeklyExpense({
+                  id: this.idProvider.get(),
+                  amount: expense.amount,
+                  date: expense.date,
+                  label: expense.label,
+                  isChecked: false,
+                })
+            ) ?? [],
         });
       }),
     });

--- a/back/src/core/factories/MonthFactory.ts
+++ b/back/src/core/factories/MonthFactory.ts
@@ -13,26 +13,16 @@ export default class MonthFactory {
     if (command.initialBalance <= 0) {
       throw new AccountInitialBalanceError();
     }
-    const outflows = command.outflows.map((outflow) => {
-      return new AccountOutflow({
-        id: this.idProvider.get(),
-        amount: outflow.amount,
-        label: outflow.label,
-      });
-    });
-    outflows.push(
-      ...command.pendingDebits.map((debit) => {
-        return new AccountOutflow({
-          id: this.idProvider.get(),
-          amount: debit.amount,
-          label: debit.label,
-        });
-      })
-    );
     const account = new Account({
       id: this.idProvider.get(),
       currentBalance: command.initialBalance,
-      outflows: outflows,
+      outflows: command.outflows.map((outflow) => {
+        return new AccountOutflow({
+          id: this.idProvider.get(),
+          amount: outflow.amount,
+          label: outflow.label,
+        });
+      }),
       weeklyBudgets: command.weeklyBudgets.map((weeklyBudget) => {
         return new WeeklyBudget({
           id: this.idProvider.get(),

--- a/back/src/core/models/month/account/WeeklyBudget.ts
+++ b/back/src/core/models/month/account/WeeklyBudget.ts
@@ -1,7 +1,4 @@
-import {
-  AccountBudgetNameCantBeEmptyError,
-  WeeklyBudgetInitialBalanceError,
-} from "../../../errors/WeeklyBudgetErrors.js";
+import { AccountBudgetNameCantBeEmptyError } from "../../../errors/WeeklyBudgetErrors.js";
 import WeeklyExpense from "./WeeklyExpense.js";
 import { WeeklyExpenseNotFoundError } from "../../../errors/WeeklyExpenseErrors.js";
 
@@ -20,9 +17,6 @@ export default class WeeklyBudget {
     initialBalance: number;
     expenses?: WeeklyExpense[];
   }) {
-    if (props.initialBalance <= 0) {
-      throw new WeeklyBudgetInitialBalanceError();
-    }
     this.initialBalance = props.initialBalance;
     this.id = props.id;
     if (props.name.length === 0) {

--- a/back/src/core/models/pending-debit/PendingBudget.ts
+++ b/back/src/core/models/pending-debit/PendingBudget.ts
@@ -5,16 +5,25 @@ export default class PendingBudget {
   readonly id: string;
   readonly name: string;
   readonly initialBalance: number;
+  readonly currentBalance: number;
   readonly expenses: WeeklyExpense[] = [];
 
   constructor(budget: WeeklyBudget, monthDate: Date) {
     this.id = budget.id;
-    this.initialBalance = budget.currentBalance;
     const pendingExpenses = budget.expenses.filter(
       (expense) => expense.isChecked === false
     );
     if (pendingExpenses.length > 0) {
       this.expenses = pendingExpenses;
+      const totalExpenses = this.expenses.reduce(
+        (total, expense) => total + expense.amount,
+        0
+      );
+      this.initialBalance = budget.currentBalance + totalExpenses;
+      this.currentBalance = this.initialBalance - totalExpenses;
+    } else {
+      this.initialBalance = budget.currentBalance;
+      this.currentBalance = this.initialBalance;
     }
     const date = monthDate;
     const options = { year: "numeric", month: "short" };

--- a/back/src/core/models/pending-debit/PendingBudget.ts
+++ b/back/src/core/models/pending-debit/PendingBudget.ts
@@ -1,0 +1,27 @@
+import WeeklyBudget from "../month/account/WeeklyBudget.js";
+import WeeklyExpense from "../month/account/WeeklyExpense.js";
+
+export default class PendingBudget {
+  readonly id: string;
+  readonly name: string;
+  readonly initialBalance: number;
+  readonly expenses: WeeklyExpense[] = [];
+
+  constructor(budget: WeeklyBudget, monthDate: Date) {
+    this.id = budget.id;
+    this.initialBalance = budget.currentBalance;
+    const pendingExpenses = budget.expenses.filter(
+      (expense) => expense.isChecked === false
+    );
+    if (pendingExpenses.length > 0) {
+      this.expenses = pendingExpenses;
+    }
+    const date = monthDate;
+    const options = { year: "numeric", month: "short" };
+    const formattedDate = date.toLocaleDateString(
+      "fr-FR",
+      options as Intl.DateTimeFormatOptions
+    );
+    this.name = `${budget.name} (${formattedDate})`;
+  }
+}

--- a/back/src/core/models/pending-debit/PendingOutflow.ts
+++ b/back/src/core/models/pending-debit/PendingOutflow.ts
@@ -1,0 +1,19 @@
+import AccountOutflow from "../month/account/AccountOutflow.js";
+
+export default class PendingOutflow {
+  readonly id: string;
+  readonly label: string;
+  readonly amount: number;
+
+  constructor(outflow: AccountOutflow, monthDate: Date) {
+    this.id = outflow.id;
+    this.amount = outflow.amount;
+    const date = monthDate;
+    const options = { year: "numeric", month: "short" };
+    const formattedDate = date.toLocaleDateString(
+      "fr-FR",
+      options as Intl.DateTimeFormatOptions
+    );
+    this.label = `${outflow.label} (${formattedDate})`;
+  }
+}

--- a/back/src/core/ports/repositories/PendingDebitRepository.ts
+++ b/back/src/core/ports/repositories/PendingDebitRepository.ts
@@ -1,7 +1,13 @@
-import PendingDebit from "../../models/pending-debit/PendingDebit.js";
+import PendingBudget from "../../models/pending-debit/PendingBudget.js";
+import PendingOutflow from "../../models/pending-debit/PendingOutflow.js";
+
+export type PendingDebits = {
+  outflows: PendingOutflow[];
+  budgets: PendingBudget[];
+};
 
 interface PendingDebitRepository {
-  getAll(): Promise<PendingDebit[]>;
+  getAll(): Promise<PendingDebits>;
 }
 
 export default PendingDebitRepository;

--- a/back/src/providers/persistence/repositories/PendingDebitRepository.ts
+++ b/back/src/providers/persistence/repositories/PendingDebitRepository.ts
@@ -1,65 +1,35 @@
-import PendingDebit from "../../../core/models/pending-debit/PendingDebit.js";
-import PendingDebitRepository from "../../../core/ports/repositories/PendingDebitRepository.js";
+import PendingBudget from "../../../core/models/pending-debit/PendingBudget.js";
+import PendingOutflow from "../../../core/models/pending-debit/PendingOutflow.js";
+import PendingDebitRepository, {
+  PendingDebits,
+} from "../../../core/ports/repositories/PendingDebitRepository.js";
 import { MonthDao } from "../entities/Month.js";
 
 export default class TypeOrmPendingDebitRepository
   implements PendingDebitRepository
 {
-  async getAll(): Promise<PendingDebit[]> {
-    const monthRepository = MonthDao.getRepository();
-
-    const outflowResults = await monthRepository
-      .createQueryBuilder("month")
-      .leftJoinAndSelect("month.account", "account")
-      .leftJoinAndSelect(
-        "account.outflows",
-        "outflow",
-        "outflow.isChecked = :isChecked"
-      )
-      .where("outflow.id IS NOT NULL")
-      .setParameter("isChecked", false)
-      .select([
-        "month.id AS month_id",
-        "month.date AS month_date",
-        "outflow.id AS outflow_id",
-        "outflow.label AS outflow_label",
-        "outflow.amount AS outflow_amount",
-        "outflow.isChecked AS outflow_is_checked",
-      ])
-      .getRawMany();
-
-    const expenseResults = await monthRepository
-      .createQueryBuilder("month")
-      .leftJoinAndSelect("month.account", "account")
-      .leftJoinAndSelect("account.weeklyBudgets", "weeklyBudget")
-      .leftJoinAndSelect(
-        "weeklyBudget.expenses",
-        "expense",
-        "expense.isChecked = :isChecked"
-      )
-      .where("expense.id IS NOT NULL")
-      .setParameter("isChecked", false)
-      .select([
-        "month.id AS month_id",
-        "month.date AS month_date",
-        "expense.id AS expense_id",
-        "expense.label AS expense_label",
-        "expense.amount AS expense_amount",
-        "expense.isChecked AS expense_is_checked",
-      ])
-      .getRawMany();
-
-    const results = [...outflowResults, ...expenseResults];
-
-    return results.map((result) => {
-      return new PendingDebit({
-        id: result.expense_id ?? result.outflow_id,
-        monthId: result.month_id,
-        monthDate: new Date(result.month_date),
-        label: result.expense_label ?? result.outflow_label,
-        amount: Number(result.expense_amount ?? result.outflow_amount),
-        type: result.expense_id ? "expense" : "outflow",
-      });
+  async getAll(): Promise<PendingDebits> {
+    const monthsFromDb = await MonthDao.find();
+    const months = monthsFromDb.map((month) => month.toDomain());
+    const budgets = months.flatMap((month) => {
+      const foundBudgets = month.account.weeklyBudgets.filter(
+        (budget) =>
+          budget.currentBalance > 0 ||
+          budget.expenses.filter((expense) => expense.isChecked === false)
+      );
+      return foundBudgets.map(
+        (budget) => new PendingBudget(budget, month.date)
+      );
     });
+    const outflows = months.flatMap((month) => {
+      return month.account.outflows
+        .filter((outflow) => outflow.isChecked === false)
+        .map((outflow) => new PendingOutflow(outflow, month.date));
+    });
+
+    return {
+      outflows,
+      budgets,
+    };
   }
 }

--- a/back/src/tests/integration/consumers/CreateNewMonth.test.ts
+++ b/back/src/tests/integration/consumers/CreateNewMonth.test.ts
@@ -24,7 +24,6 @@ describe("Integration | Consumers | Routes | POST /months", function () {
       const body = {
         month: new Date(),
         startingBalance: 2000,
-        pendingDebits: [],
         outflows: [
           {
             label: "outlfow",
@@ -78,7 +77,6 @@ describe("Integration | Consumers | Routes | POST /months", function () {
             amount: 10.05,
           },
         ],
-        pendingDebits: [],
         weeklyBudgets: [
           {
             name: "Semaine 1",
@@ -132,7 +130,6 @@ describe("Integration | Consumers | Routes | POST /months", function () {
       const body = {
         month: new Date(),
         startingBalance: -2000,
-        pendingDebits: [],
         outflows: [
           {
             label: "outlfow",

--- a/back/src/tests/integration/providers/persistence/repositories/MonthRepository.test.ts
+++ b/back/src/tests/integration/providers/persistence/repositories/MonthRepository.test.ts
@@ -33,16 +33,6 @@ describe("Integration | Providers | Persistence | Repositories | MonthRepository
       const newMonth = monthFactory.create({
         date: new Date(),
         initialBalance: 2000,
-        pendingDebits: [
-          {
-            id: "8d2eead7-f41d-4e6c-9c52-d0f81c22a21b",
-            monthId: "a8ac22b1-0090-494a-a3fe-9ec2526cf8d1",
-            monthDate: new Date(),
-            label: "label",
-            amount: 10,
-            type: "outflow",
-          },
-        ],
         outflows: [
           {
             label: "outlfow",
@@ -79,7 +69,7 @@ describe("Integration | Providers | Persistence | Repositories | MonthRepository
       // then
       expect(persistedMonth).to.be.instanceof(Month);
       expect(persistedMonth.id).to.be.equal(newMonth.id);
-      expect(persistedMonth.account.outflows).to.have.lengthOf(2);
+      expect(persistedMonth.account.outflows).to.have.lengthOf(1);
       expect(persistedMonth.account.weeklyBudgets).to.have.lengthOf(5);
     });
   });

--- a/back/src/tests/integration/providers/persistence/repositories/PendingDebitRepository.test.ts
+++ b/back/src/tests/integration/providers/persistence/repositories/PendingDebitRepository.test.ts
@@ -1,15 +1,17 @@
 import { afterEach } from "mocha";
-import expect from "../../../../test-helpers.js";
 import { clearDB } from "../../test-helpers.js";
-import { insertArchivedMonth } from "../../../../utils/persistence/seeds/MonthSeeds.js";
-import MonthBuilder from "../../../../utils/models/MonthBuilder.js";
-import AccountOutflow from "../../../../../core/models/month/account/AccountOutflow.js";
-import WeeklyExpense from "../../../../../core/models/month/account/WeeklyExpense.js";
+import expect from "../../../../test-helpers.js";
 import PendingDebitRepository from "../../../../../providers/persistence/repositories/PendingDebitRepository.js";
-import PendingDebit from "../../../../../core/models/pending-debit/PendingDebit.js";
+import PendingBudget from "../../../../../core/models/pending-debit/PendingBudget.js";
+import PendingOutflow from "../../../../../core/models/pending-debit/PendingOutflow.js";
+import Month from "../../../../../core/models/month/Month.js";
+import Account from "../../../../../core/models/month/account/Account.js";
+import AccountOutflow from "../../../../../core/models/month/account/AccountOutflow.js";
+import WeeklyBudget from "../../../../../core/models/month/account/WeeklyBudget.js";
+import WeeklyExpense from "../../../../../core/models/month/account/WeeklyExpense.js";
 import { MonthDao } from "../../../../../providers/persistence/entities/Month.js";
 
-describe("Integration | Providers | Persistence | Repositories | PendingDebitRepository", () => {
+describe.only("Integration | Providers | Persistence | Repositories | PendingDebitRepository", () => {
   afterEach(async () => {
     await clearDB();
   });
@@ -18,94 +20,166 @@ describe("Integration | Providers | Persistence | Repositories | PendingDebitRep
     it("should return all pending debits from existing months", async () => {
       // Given
       const repository = new PendingDebitRepository();
-      const expectedOutflow = new AccountOutflow({
-        id: "30db1d8e-0c83-4f11-b504-6addc219d771",
+      const checkedOutflowFromArchivedMonth = new AccountOutflow({
+        id: "e55446c4-8edd-40f0-8820-952cc6d135b2",
         amount: 10,
-        label: "unchecked-outflow-label",
+        label: "JOW",
+        isChecked: true,
       });
-      const expectedExpense = new WeeklyExpense({
-        id: "531ab735-b13e-434c-869f-6b2f91bf7ea9",
+      const uncheckedOutflowFromArchivedMonth = new AccountOutflow({
+        id: "f8f625c9-2d76-4469-9a2b-a3c38ba07685",
         amount: 10,
-        label: "unchecked-expense-label",
-        date: new Date(),
+        label: "JODI",
+        isChecked: false,
       });
-      const monthDate = new Date("2022-01-01");
-      const persistedMonth = await insertMonth(
-        monthDate,
-        expectedOutflow,
-        expectedExpense
-      );
+      const positiveBudgetForArchivedMonth = new WeeklyBudget({
+        id: "5ead27cb-b97b-4235-b158-aa564c0e322d",
+        initialBalance: 200,
+        name: "Vacances",
+        expenses: [
+          new WeeklyExpense({
+            id: "295a1547-d06a-4112-bd49-18c57e8fe7da",
+            amount: 5,
+            label: "Vaps",
+            isChecked: true,
+            date: new Date(),
+          }),
+          new WeeklyExpense({
+            id: "ce31d014-6b91-469e-9797-5d29d38760ea",
+            amount: 5,
+            label: "Resto",
+            isChecked: false,
+            date: new Date(),
+          }),
+        ],
+      });
+      const negativeBudgetForArchivedMonth = new WeeklyBudget({
+        id: "eb5a00ec-55a2-4bda-a9dd-35878dbf64f2",
+        initialBalance: 200,
+        name: "Vacances",
+        expenses: [
+          new WeeklyExpense({
+            id: "a525fe6d-fe1f-4462-8e80-95f62c150ca9",
+            amount: 180,
+            label: "Vaps",
+            isChecked: true,
+            date: new Date(),
+          }),
+          new WeeklyExpense({
+            id: "87114c19-d555-4bb5-b969-b0c29525e5c8",
+            amount: 30,
+            label: "Resto",
+            isChecked: false,
+            date: new Date(),
+          }),
+        ],
+      });
+      const archivedMonth = new Month({
+        id: "bd9a84b1-7e5a-477d-88af-bec3098ddfd7",
+        date: new Date("2024-02-01"),
+        isArchived: true,
+        account: new Account({
+          id: "e6fd73cb-a385-489e-8e75-fbdb9a9d9414",
+          currentBalance: 1000,
+          outflows: [
+            checkedOutflowFromArchivedMonth,
+            uncheckedOutflowFromArchivedMonth,
+          ],
+          weeklyBudgets: [
+            positiveBudgetForArchivedMonth,
+            negativeBudgetForArchivedMonth,
+          ],
+        }),
+      });
+      await MonthDao.save(MonthDao.fromDomain(archivedMonth));
+
+      const checkedOutflowFromUnarchivedMonth = new AccountOutflow({
+        id: "edf76ebc-b124-4966-9f30-8f5294fe21ec",
+        amount: 10,
+        label: "JOW",
+        isChecked: true,
+      });
+      const uncheckedOutflowFromUnarchivedMonth = new AccountOutflow({
+        id: "ca8ffd5b-3d9d-42d5-a5fc-967183a43a68",
+        amount: 10,
+        label: "JODI",
+        isChecked: false,
+      });
+      const positiveBudgetForUnarchivedMonth = new WeeklyBudget({
+        id: "6a4d7d01-88e9-4dca-be39-98b670ffd91b",
+        initialBalance: 200,
+        name: "Vacances",
+        expenses: [
+          new WeeklyExpense({
+            id: "b62e2c61-419e-4096-820c-301876bb89a0",
+            amount: 5,
+            label: "Vaps",
+            isChecked: true,
+            date: new Date(),
+          }),
+          new WeeklyExpense({
+            id: "f0f63029-549e-4980-a96c-bf7b336ccea3",
+            amount: 5,
+            label: "Resto",
+            isChecked: false,
+            date: new Date(),
+          }),
+        ],
+      });
+      const zeroBudgetForUnarchivedMonth = new WeeklyBudget({
+        id: "7b7487c4-aa5f-4f72-a691-1567006e74f0",
+        initialBalance: 200,
+        name: "Vacances",
+        expenses: [
+          new WeeklyExpense({
+            id: "f942d78f-3e67-4500-86eb-656f09dfe9a8",
+            amount: 180,
+            label: "Vaps",
+            isChecked: true,
+            date: new Date(),
+          }),
+          new WeeklyExpense({
+            id: "4b49db4d-3baa-45cc-8cc0-8e8c63b36cc6",
+            amount: 20,
+            label: "Resto",
+            isChecked: false,
+            date: new Date(),
+          }),
+        ],
+      });
+      const unarchivedMonth = new Month({
+        id: "5da6c3fd-c213-45ed-86d4-c9cb3d526efd",
+        date: new Date("2024-02-01"),
+        isArchived: false,
+        account: new Account({
+          id: "16e186a0-c834-4e00-8c10-8ebd424e4285",
+          currentBalance: 1000,
+          outflows: [
+            checkedOutflowFromUnarchivedMonth,
+            uncheckedOutflowFromUnarchivedMonth,
+          ],
+          weeklyBudgets: [
+            positiveBudgetForUnarchivedMonth,
+            zeroBudgetForUnarchivedMonth,
+          ],
+        }),
+      });
+      await MonthDao.save(MonthDao.fromDomain(archivedMonth));
+      await MonthDao.save(MonthDao.fromDomain(unarchivedMonth));
 
       // When
-      const debits = await repository.getAll();
+      const pendingDebits = await repository.getAll();
 
       // Then
-      debits.forEach((debit) => {
-        expect(debit).instanceOf(PendingDebit);
+      pendingDebits.budgets.forEach((budget) => {
+        expect(budget).to.be.instanceOf(PendingBudget);
       });
-      expect(debits).to.have.length(2);
-      const outflowDebit = debits.find((debit) => debit.type === "outflow");
-      assertDebitEquality(
-        outflowDebit,
-        expectedOutflow,
-        monthDate,
-        persistedMonth
-      );
+      expect(pendingDebits.budgets).to.have.length(4);
 
-      const expenseDebit = debits.find((debit) => debit.type === "expense");
-      assertDebitEquality(
-        expenseDebit,
-        expectedExpense,
-        monthDate,
-        persistedMonth
-      );
+      pendingDebits.outflows.forEach((outflow) => {
+        expect(outflow).to.be.instanceOf(PendingOutflow);
+      });
+      expect(pendingDebits.outflows).to.have.length(2);
     });
   });
 });
-
-function assertDebitEquality(
-  givenDebit: PendingDebit | undefined,
-  expectedDebit: AccountOutflow | WeeklyExpense,
-  monthDate: Date,
-  persistedMonth: MonthDao
-) {
-  expect(givenDebit).not.to.be.undefined;
-  expect(givenDebit?.id).to.be.equal(expectedDebit.id);
-  expect(givenDebit?.amount).to.be.equal(expectedDebit.amount);
-  expect(givenDebit?.label).to.be.equal(`${expectedDebit.label} (janv. 2022)`);
-  expect(givenDebit?.monthDate.getTime()).to.be.equal(monthDate.getTime());
-  expect(givenDebit?.monthId).to.be.equal(persistedMonth.id);
-}
-
-async function insertMonth(
-  monthDate: Date,
-  expectedOutflow: AccountOutflow,
-  expectedExpense: WeeklyExpense
-) {
-  const monthBuilder = new MonthBuilder();
-  const month = monthBuilder.add
-    .outflow(expectedOutflow)
-    .add.outflow(
-      new AccountOutflow({
-        id: "e024f6e8-3741-43cb-93e0-9eecbe55f4c9",
-        amount: 10,
-        label: "checked-outflow-label",
-        isChecked: true,
-      })
-    )
-    .add.expense(expectedExpense)
-    .toWeek("Semaine 1")
-    .add.expense(
-      new WeeklyExpense({
-        id: "5f74814a-0f76-4a1d-a490-eb7882baa21e",
-        amount: 10,
-        label: "checked-expense-label",
-        date: new Date(),
-        isChecked: true,
-      })
-    )
-    .toWeek("Semaine 1")
-    .get(monthDate);
-
-  return insertArchivedMonth(month);
-}

--- a/back/src/tests/integration/providers/persistence/repositories/PendingDebitRepository.test.ts
+++ b/back/src/tests/integration/providers/persistence/repositories/PendingDebitRepository.test.ts
@@ -11,7 +11,7 @@ import WeeklyBudget from "../../../../../core/models/month/account/WeeklyBudget.
 import WeeklyExpense from "../../../../../core/models/month/account/WeeklyExpense.js";
 import { MonthDao } from "../../../../../providers/persistence/entities/Month.js";
 
-describe.only("Integration | Providers | Persistence | Repositories | PendingDebitRepository", () => {
+describe("Integration | Providers | Persistence | Repositories | PendingDebitRepository", () => {
   afterEach(async () => {
     await clearDB();
   });

--- a/back/src/tests/unit/consumers/deserializers/monthCreation.test.ts
+++ b/back/src/tests/unit/consumers/deserializers/monthCreation.test.ts
@@ -5,16 +5,6 @@ describe("Unit | Consumers | deserializers | monthCreation", function () {
   const body = {
     month: new Date(),
     startingBalance: 2000,
-    pendingDebits: [
-      {
-        id: "8d2eead7-f41d-4e6c-9c52-d0f81c22a21b",
-        monthId: "a8ac22b1-0090-494a-a3fe-9ec2526cf8d1",
-        monthDate: new Date(),
-        label: "label",
-        amount: 10,
-        type: "outflow",
-      },
-    ],
     outflows: [
       {
         label: "outlfow",
@@ -37,16 +27,6 @@ describe("Unit | Consumers | deserializers | monthCreation", function () {
     expect(command).to.deep.equal({
       date: body.month,
       initialBalance: body.startingBalance,
-      pendingDebits: [
-        {
-          id: body.pendingDebits[0].id,
-          monthId: body.pendingDebits[0].monthId,
-          monthDate: body.pendingDebits[0].monthDate,
-          label: body.pendingDebits[0].label,
-          amount: body.pendingDebits[0].amount,
-          type: body.pendingDebits[0].type,
-        },
-      ],
       outflows: [
         {
           label: body.outflows[0].label,

--- a/back/src/tests/unit/consumers/deserializers/monthCreation.test.ts
+++ b/back/src/tests/unit/consumers/deserializers/monthCreation.test.ts
@@ -3,7 +3,7 @@ import deserializer from "../../../../consumers/api/deserializers/monthCreation.
 
 describe("Unit | Consumers | deserializers | monthCreation", function () {
   const body = {
-    month: new Date(),
+    month: new Date().toISOString(),
     startingBalance: 2000,
     outflows: [
       {
@@ -15,6 +15,13 @@ describe("Unit | Consumers | deserializers | monthCreation", function () {
       {
         name: "Semaine 1",
         initialBalance: 200,
+        expenses: [
+          {
+            label: "outlfow",
+            amount: 10.05,
+            date: new Date().toISOString(),
+          },
+        ],
       },
     ],
   };
@@ -25,18 +32,22 @@ describe("Unit | Consumers | deserializers | monthCreation", function () {
 
     // then
     expect(command).to.deep.equal({
-      date: body.month,
+      date: new Date(body.month),
       initialBalance: body.startingBalance,
       outflows: [
         {
-          label: body.outflows[0].label,
-          amount: body.outflows[0].amount,
+          ...body.outflows[0],
         },
       ],
       weeklyBudgets: [
         {
-          name: body.weeklyBudgets[0].name,
-          initialBalance: body.weeklyBudgets[0].initialBalance,
+          ...body.weeklyBudgets[0],
+          expenses: [
+            {
+              ...body.weeklyBudgets[0].expenses[0],
+              date: new Date(body.weeklyBudgets[0].expenses[0].date),
+            },
+          ],
         },
       ],
     });

--- a/back/src/tests/unit/core/factories/MonthFactory.test.ts
+++ b/back/src/tests/unit/core/factories/MonthFactory.test.ts
@@ -18,16 +18,6 @@ describe("Unit | Core | Factories | MonthFactory", function () {
       const command = {
         date: new Date(),
         initialBalance: 2000,
-        pendingDebits: [
-          {
-            id: "8d2eead7-f41d-4e6c-9c52-d0f81c22a21b",
-            monthId: "a8ac22b1-0090-494a-a3fe-9ec2526cf8d1",
-            monthDate: new Date(),
-            label: "label",
-            amount: 10,
-            type: "outflow",
-          } as PendingDebitProps,
-        ],
         outflows: [
           {
             label: "outlfow",
@@ -63,7 +53,7 @@ describe("Unit | Core | Factories | MonthFactory", function () {
 
       // then
       expect(month).to.be.instanceof(Month);
-      expect(month.account.outflows).to.have.lengthOf(2);
+      expect(month.account.outflows).to.have.lengthOf(1);
       expect(month.account.weeklyBudgets).to.have.lengthOf(5);
     });
     it("should throw an error if current balance is negative", function () {
@@ -77,16 +67,6 @@ describe("Unit | Core | Factories | MonthFactory", function () {
       const command = {
         date: new Date(),
         initialBalance: -2000,
-        pendingDebits: [
-          {
-            id: "8d2eead7-f41d-4e6c-9c52-d0f81c22a21b",
-            monthId: "a8ac22b1-0090-494a-a3fe-9ec2526cf8d1",
-            monthDate: new Date(),
-            label: "label",
-            amount: 10,
-            type: "outflow",
-          } as PendingDebitProps,
-        ],
         outflows: [
           {
             label: "outlfow",
@@ -133,16 +113,6 @@ describe("Unit | Core | Factories | MonthFactory", function () {
       const command = {
         date: new Date(),
         initialBalance: 0,
-        pendingDebits: [
-          {
-            id: "8d2eead7-f41d-4e6c-9c52-d0f81c22a21b",
-            monthId: "a8ac22b1-0090-494a-a3fe-9ec2526cf8d1",
-            monthDate: new Date(),
-            label: "label",
-            amount: 10,
-            type: "outflow",
-          } as PendingDebitProps,
-        ],
         outflows: [
           {
             label: "outlfow",

--- a/back/src/tests/unit/core/factories/MonthFactory.test.ts
+++ b/back/src/tests/unit/core/factories/MonthFactory.test.ts
@@ -3,7 +3,6 @@ import sinon from "sinon";
 import Month from "../../../../core/models/month/Month.js";
 import MonthFactory from "../../../../core/factories/MonthFactory.js";
 import { AccountInitialBalanceError } from "../../../../core/errors/AccountErrors.js";
-import { PendingDebitProps } from "../../../../core/models/pending-debit/PendingDebit.js";
 
 describe("Unit | Core | Factories | MonthFactory", function () {
   describe("#create", function () {
@@ -28,22 +27,7 @@ describe("Unit | Core | Factories | MonthFactory", function () {
           {
             name: "Semaine 1",
             initialBalance: 200,
-          },
-          {
-            name: "Semaine 2",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 3",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 4",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 5",
-            initialBalance: 200,
+            expenses: [],
           },
         ],
       };
@@ -54,7 +38,7 @@ describe("Unit | Core | Factories | MonthFactory", function () {
       // then
       expect(month).to.be.instanceof(Month);
       expect(month.account.outflows).to.have.lengthOf(1);
-      expect(month.account.weeklyBudgets).to.have.lengthOf(5);
+      expect(month.account.weeklyBudgets).to.have.lengthOf(1);
     });
     it("should throw an error if current balance is negative", function () {
       // given
@@ -77,22 +61,7 @@ describe("Unit | Core | Factories | MonthFactory", function () {
           {
             name: "Semaine 1",
             initialBalance: 200,
-          },
-          {
-            name: "Semaine 2",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 3",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 4",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 5",
-            initialBalance: 200,
+            expenses: [],
           },
         ],
       };
@@ -123,22 +92,7 @@ describe("Unit | Core | Factories | MonthFactory", function () {
           {
             name: "Semaine 1",
             initialBalance: 200,
-          },
-          {
-            name: "Semaine 2",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 3",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 4",
-            initialBalance: 200,
-          },
-          {
-            name: "Semaine 5",
-            initialBalance: 200,
+            expenses: [],
           },
         ],
       };

--- a/back/src/tests/unit/core/models/month/account/WeeklyBudget.test.ts
+++ b/back/src/tests/unit/core/models/month/account/WeeklyBudget.test.ts
@@ -1,10 +1,7 @@
 import expect from "../../../../../test-helpers.js";
 import sinon from "sinon";
 import WeeklyBudget from "../../../../../../core/models/month/account/WeeklyBudget.js";
-import {
-  AccountBudgetNameCantBeEmptyError,
-  WeeklyBudgetInitialBalanceError,
-} from "../../../../../../core/errors/WeeklyBudgetErrors.js";
+import { AccountBudgetNameCantBeEmptyError } from "../../../../../../core/errors/WeeklyBudgetErrors.js";
 import WeeklyExpense from "../../../../../../core/models/month/account/WeeklyExpense.js";
 import { WeeklyExpenseNotFoundError } from "../../../../../../core/errors/WeeklyExpenseErrors.js";
 
@@ -142,32 +139,6 @@ describe("Unit | Core | Models | Month | Account | WeeklyBudget", function () {
         endAt: null,
         expenses: [],
       });
-    });
-    it("should throw an error if current balance is negative", function () {
-      // given
-      const props = {
-        id: "uuid",
-        name: "Semaine 1",
-        initialBalance: -200,
-      };
-
-      // when / then
-      expect(() => new WeeklyBudget(props)).to.throw(
-        WeeklyBudgetInitialBalanceError
-      );
-    });
-    it("should throw an error if current balance is 0", function () {
-      // given
-      const props = {
-        id: "uuid",
-        name: "Semaine 1",
-        initialBalance: 0,
-      };
-
-      // when / then
-      expect(() => new WeeklyBudget(props)).to.throw(
-        WeeklyBudgetInitialBalanceError
-      );
     });
   });
   describe("#addExpense", function () {

--- a/back/src/tests/unit/core/models/pending-debit/PendingBudget.test.ts
+++ b/back/src/tests/unit/core/models/pending-debit/PendingBudget.test.ts
@@ -5,7 +5,7 @@ import WeeklyExpense from "../../../../../core/models/month/account/WeeklyExpens
 
 describe("unit | core | models | pending-debit | PendingBudget", () => {
   describe("#constructor", () => {
-    it("should instantiate pending debit with right data", () => {
+    it("should instantiate pending debit with right data with expenses", () => {
       // Given
       const checkedExpense = new WeeklyExpense({
         id: "uuid",
@@ -37,10 +37,30 @@ describe("unit | core | models | pending-debit | PendingBudget", () => {
       expect(pendingBudget.name).to.be.deep.equal(
         `${budget.name} (janv. 2022)`
       );
-      expect(pendingBudget.initialBalance).to.be.deep.equal(
-        budget.currentBalance
-      );
+      expect(pendingBudget.initialBalance).to.equal(190);
+      expect(pendingBudget.currentBalance).to.equal(170);
       expect(pendingBudget.expenses).to.deep.equal([uncheckedExpense]);
+    });
+
+    it("should instantiate pending debit with right data without expenses", () => {
+      // Given
+      const budget = new WeeklyBudget({
+        id: "uuid",
+        name: "Semaine 1",
+        initialBalance: 200,
+      });
+      const monthDate = new Date("2022-01-01");
+
+      // When
+      const pendingBudget = new PendingBudget(budget, monthDate);
+
+      // Then
+      expect(pendingBudget.id).to.be.deep.equal(budget.id);
+      expect(pendingBudget.name).to.be.deep.equal(
+        `${budget.name} (janv. 2022)`
+      );
+      expect(pendingBudget.initialBalance).to.equal(200);
+      expect(pendingBudget.currentBalance).to.equal(200);
     });
   });
 });

--- a/back/src/tests/unit/core/models/pending-debit/PendingBudget.test.ts
+++ b/back/src/tests/unit/core/models/pending-debit/PendingBudget.test.ts
@@ -1,0 +1,46 @@
+import expect from "../../../../test-helpers.js";
+import PendingBudget from "../../../../../core/models/pending-debit/PendingBudget.js";
+import WeeklyBudget from "../../../../../core/models/month/account/WeeklyBudget.js";
+import WeeklyExpense from "../../../../../core/models/month/account/WeeklyExpense.js";
+
+describe("unit | core | models | pending-debit | PendingBudget", () => {
+  describe("#constructor", () => {
+    it("should instantiate pending debit with right data", () => {
+      // Given
+      const checkedExpense = new WeeklyExpense({
+        id: "uuid",
+        label: "JOW",
+        amount: 10,
+        date: new Date(),
+        isChecked: true,
+      });
+      const uncheckedExpense = new WeeklyExpense({
+        id: "uuid",
+        label: "JOW",
+        amount: 20,
+        date: new Date(),
+        isChecked: false,
+      });
+      const budget = new WeeklyBudget({
+        id: "uuid",
+        name: "Semaine 1",
+        initialBalance: 200,
+        expenses: [checkedExpense, uncheckedExpense],
+      });
+      const monthDate = new Date("2022-01-01");
+
+      // When
+      const pendingBudget = new PendingBudget(budget, monthDate);
+
+      // Then
+      expect(pendingBudget.id).to.be.deep.equal(budget.id);
+      expect(pendingBudget.name).to.be.deep.equal(
+        `${budget.name} (janv. 2022)`
+      );
+      expect(pendingBudget.initialBalance).to.be.deep.equal(
+        budget.currentBalance
+      );
+      expect(pendingBudget.expenses).to.deep.equal([uncheckedExpense]);
+    });
+  });
+});

--- a/back/src/tests/unit/core/models/pending-debit/PendingOutflow.test.ts
+++ b/back/src/tests/unit/core/models/pending-debit/PendingOutflow.test.ts
@@ -1,0 +1,28 @@
+import expect from "../../../../test-helpers.js";
+import PendingOutflow from "../../../../../core/models/pending-debit/PendingOutflow.js";
+import AccountOutflow from "../../../../../core/models/month/account/AccountOutflow.js";
+
+describe("unit | core | models | pending-debit | PendingOutflow", () => {
+  describe("#constructor", () => {
+    it("should instantiate pending debit with right data", () => {
+      // Given
+      const outflow = new AccountOutflow({
+        id: "uuid",
+        label: "outlfow",
+        amount: 10.05,
+        isChecked: true,
+      });
+      const monthDate = new Date("2022-01-01");
+
+      // When
+      const pendingOutflow = new PendingOutflow(outflow, monthDate);
+
+      // Then
+      expect(pendingOutflow.id).to.be.deep.equal(outflow.id);
+      expect(pendingOutflow.label).to.be.deep.equal(
+        `${outflow.label} (janv. 2022)`
+      );
+      expect(pendingOutflow.amount).to.be.deep.equal(outflow.amount);
+    });
+  });
+});

--- a/back/src/tests/unit/core/usecases/CreateNewMonth.test.ts
+++ b/back/src/tests/unit/core/usecases/CreateNewMonth.test.ts
@@ -20,22 +20,7 @@ describe("Unit | Core | Usecases | CreateNewMonth", function () {
         {
           name: "Semaine 1",
           initialBalance: 200,
-        },
-        {
-          name: "Semaine 2",
-          initialBalance: 200,
-        },
-        {
-          name: "Semaine 3",
-          initialBalance: 200,
-        },
-        {
-          name: "Semaine 4",
-          initialBalance: 200,
-        },
-        {
-          name: "Semaine 5",
-          initialBalance: 200,
+          expenses: [],
         },
       ],
     };

--- a/back/src/tests/unit/core/usecases/CreateNewMonth.test.ts
+++ b/back/src/tests/unit/core/usecases/CreateNewMonth.test.ts
@@ -3,7 +3,6 @@ import expect from "../../../test-helpers.js";
 import MonthCreationCommand from "../../../../core/commands/MonthCreationCommand.js";
 import CreateNewMonth from "../../../../core/usecases/CreateNewMonth.js";
 import { monthRepositoryStub } from "./test-helpers.js";
-import { PendingDebitProps } from "../../../../core/models/pending-debit/PendingDebit.js";
 
 describe("Unit | Core | Usecases | CreateNewMonth", function () {
   it("should return a new created month", async function () {
@@ -11,16 +10,6 @@ describe("Unit | Core | Usecases | CreateNewMonth", function () {
     const command: MonthCreationCommand = {
       date: new Date(),
       initialBalance: 2000,
-      pendingDebits: [
-        {
-          id: "8d2eead7-f41d-4e6c-9c52-d0f81c22a21b",
-          monthId: "a8ac22b1-0090-494a-a3fe-9ec2526cf8d1",
-          monthDate: new Date(),
-          label: "label",
-          amount: 10,
-          type: "outflow",
-        } as PendingDebitProps,
-      ],
       outflows: [
         {
           label: "outlfow",

--- a/front-v2/src/app/components/archived-months/archived-months.component.ts
+++ b/front-v2/src/app/components/archived-months/archived-months.component.ts
@@ -7,7 +7,6 @@ import {
   signal,
   Signal,
 } from '@angular/core';
-import { Router } from '@angular/router';
 import { MonthlyBudget } from '../../models/monthlyBudget.model';
 import {
   MONTHLY_BUDGETS_STORE,
@@ -45,7 +44,6 @@ export class ArchivedMonthsComponent implements OnInit {
   openMenuModal = false;
 
   constructor(
-    private router: Router,
     private injector: Injector,
     @Inject(MONTHLY_BUDGETS_STORE)
     private monthlyBudgetsStore: MonthlyBudgetsStoreInterface,
@@ -96,7 +94,12 @@ export class ArchivedMonthsComponent implements OnInit {
     this.deleteMonthLoading = true;
     this.monthsService
       .deleteMonth(month.id)
-      .pipe(finalize(() => (this.deleteMonthLoading = false)))
+      .pipe(
+        finalize(() => {
+          this.deleteMonthLoading = false;
+          this.openMenuModal = false;
+        })
+      )
       .subscribe(() => this.toaster.success('Votre mois a été supprimé !'));
   }
 

--- a/front-v2/src/app/components/month-creation/month-creation.component.html
+++ b/front-v2/src/app/components/month-creation/month-creation.component.html
@@ -240,7 +240,7 @@
             budget.get("name")?.value
           }}</span>
           <span class="month-creation-item-info__amount"
-            >{{ budget.get("initialBalance")?.value }}€&nbsp;
+            >{{ budget.get("currentBalance")?.value }}€&nbsp;
             <span class="month-creation-item-info__label">{{
               getBudgetExpensesInfo(budget.get("id")?.value)
             }}</span>

--- a/front-v2/src/app/components/month-creation/month-creation.component.html
+++ b/front-v2/src/app/components/month-creation/month-creation.component.html
@@ -31,7 +31,7 @@
     [variant]="'danger'"
     [label]="'Supprimer la sortie définitivement'"
     [loading]="removeIsLoading"
-    (click)="removePendingDebit($event)"
+    (click)="removePendingOutflow($event)"
   ></app-button>
 </app-modal>
 @if(!dataLoaded) {
@@ -192,30 +192,30 @@
   <!-- 
   ##################### PENDING DEBITS #####################
    -->
-  @if (pendingDebits.controls.length > 0) {
+  @if (pendingOutflows.controls.length > 0) {
   <div
     class="month-creation__step month-creation__step--step_debits"
-    formArrayName="pendingDebits"
+    formArrayName="pendingOutflows"
   >
     <div class="month-creation-step__info">
       Voici les dépenses des mois précédents qui n'ont pas encore été prélevées.
       <br />
       <span class="month-creation-step-info__total">
-        Total : {{ getPendingDebitsTotal() | currency : "EUR" }}
+        Total : {{ getPendingOutflowsTotal() | currency : "EUR" }}
       </span>
       <br />
       <app-button-link
-        (onClick)="togglePendingDebits()"
+        (onClick)="togglePendingOutflows()"
         class="month-creation-step-info__link"
       >
-        @if(takeIntoAccountPendingDebits) { Ne pas les prendre en compte dans le
-        solde prévisionnel } @else { Les prendre en compte dans le solde
+        @if(takeIntoAccountPendingOutflows) { Ne pas les prendre en compte dans
+        le solde prévisionnel } @else { Les prendre en compte dans le solde
         prévisionnel }
       </app-button-link>
     </div>
-    @if(takeIntoAccountPendingDebits) {
+    @if(takeIntoAccountPendingOutflows) {
     <app-item
-      *ngFor="let debit of pendingDebits.controls; let i = index"
+      *ngFor="let debit of pendingOutflows.controls; let i = index"
       [formGroupName]="i"
     >
       <div class="month-creation-item">

--- a/front-v2/src/app/components/month-creation/month-creation.component.html
+++ b/front-v2/src/app/components/month-creation/month-creation.component.html
@@ -1,3 +1,4 @@
+<!-- REMOVE YEARLY OUTFLOW MODAL -->
 <app-modal
   [modalOpen]="yearlyOutflowDelationModalIsOpen"
   (click)="closeYearlyOutflowDelationModal($event)"
@@ -5,11 +6,11 @@
   <app-button
     [size]="'big'"
     [variant]="'danger'"
-    [label]="'Supprimer la sortie définitivement'"
-    [loading]="removeIsLoading"
+    [label]="'Supprimer la sortie'"
     (click)="removeYearlyOutflow($event)"
   ></app-button>
 </app-modal>
+<!-- REMOVE YEARLY BUDGET MODAL -->
 <app-modal
   [modalOpen]="yearlyBudgetDelationModalIsOpen"
   (click)="closeYearlyBudgetDelationModal($event)"
@@ -17,21 +18,32 @@
   <app-button
     [size]="'big'"
     [variant]="'danger'"
-    [label]="'Supprimer la sortie définitivement'"
-    [loading]="removeIsLoading"
+    [label]="'Supprimer le budget'"
     (click)="removeYearlyBudget($event)"
   ></app-button>
 </app-modal>
+<!-- REMOVE PENDING OUTFLOW MODAL -->
 <app-modal
-  [modalOpen]="pendingDebitDelationModalIsOpen"
-  (click)="closePendingDebitDelationModal($event)"
+  [modalOpen]="pendingOutflowsDelationModalIsOpen"
+  (click)="closePendingOutflowDelationModal($event)"
 >
   <app-button
     [size]="'big'"
     [variant]="'danger'"
-    [label]="'Supprimer la sortie définitivement'"
-    [loading]="removeIsLoading"
+    [label]="'Supprimer la sortie'"
     (click)="removePendingOutflow($event)"
+  ></app-button>
+</app-modal>
+<!-- REMOVE PENDING BUDGET MODAL -->
+<app-modal
+  [modalOpen]="pendingBudgetsDelationModalIsOpen"
+  (click)="closePendingBudgetDelationModal($event)"
+>
+  <app-button
+    [size]="'big'"
+    [variant]="'danger'"
+    [label]="'Supprimer le budget'"
+    (click)="removePendingBudget($event)"
   ></app-button>
 </app-modal>
 @if(!dataLoaded) {
@@ -107,7 +119,7 @@
     </div>
     @if(takeIntoAccountYearlyBudgets) {
     <app-item
-      *ngFor="let outflow of yearlyBudgetsControls.controls; let i = index"
+      *ngFor="let budget of yearlyBudgetsControls.controls; let i = index"
       [formGroupName]="i"
     >
       <div class="month-creation-item">
@@ -116,11 +128,11 @@
         </span>
         <div class="month-creation-item__info">
           <span class="month-creation-item-info__label">{{
-            outflow.get("name")?.value
+            budget.get("name")?.value
           }}</span>
           <span class="month-creation-item-info__amount"
-            >{{ outflow.get("initialBalance")?.value }}€</span
-          >
+            >{{ budget.get("initialBalance")?.value }}€
+          </span>
         </div>
         <button
           class="month-creation-item__delete"
@@ -190,7 +202,65 @@
   }
 
   <!-- 
-  ##################### PENDING DEBITS #####################
+  ##################### PENDING BUDGETS #####################
+   -->
+  @if (pendingBudgets.controls.length > 0) {
+  <div
+    class="month-creation__step month-creation__step--step_debits"
+    formArrayName="pendingBudgets"
+  >
+    <div class="month-creation-step__info">
+      Voici les budgets des mois précédents qui seront transférés dans le
+      nouveau mois.
+      <br />
+      <span class="month-creation-step-info__total">
+        Total : {{ getPendingBudgetsTotal() | currency : "EUR" }}
+      </span>
+      <br />
+      <app-button-link
+        (onClick)="togglePendingBudgets()"
+        class="month-creation-step-info__link"
+      >
+        @if(takeIntoAccountPendingBudgets) { Ne pas les prendre en compte dans
+        le solde prévisionnel } @else { Les prendre en compte dans le solde
+        prévisionnel }
+      </app-button-link>
+    </div>
+    @if(takeIntoAccountPendingBudgets) {
+    <app-item
+      *ngFor="let budget of pendingBudgets.controls; let i = index"
+      [formGroupName]="i"
+    >
+      <div class="month-creation-item">
+        <span class="month-creation-item__icon">
+          <i class="fa-solid fa-basket-shopping"></i>
+        </span>
+        <div class="month-creation-item__info">
+          <span class="month-creation-item-info__label">{{
+            budget.get("name")?.value
+          }}</span>
+          <span class="month-creation-item-info__amount"
+            >{{ budget.get("initialBalance")?.value }}€&nbsp;
+            <span class="month-creation-item-info__label">{{
+              getBudgetExpensesInfo(budget.get("id")?.value)
+            }}</span>
+          </span>
+        </div>
+        <button
+          class="month-creation-item__delete"
+          type="button"
+          (click)="openPendingBudgetDelationModal(i, $event)"
+        >
+          <i class="fa-solid fa-trash-can"></i>
+        </button>
+      </div>
+    </app-item>
+    }
+  </div>
+  }
+
+  <!-- 
+  ##################### PENDING OUTFLOWS #####################
    -->
   @if (pendingOutflows.controls.length > 0) {
   <div
@@ -198,7 +268,8 @@
     formArrayName="pendingOutflows"
   >
     <div class="month-creation-step__info">
-      Voici les dépenses des mois précédents qui n'ont pas encore été prélevées.
+      Voici les sorties des mois précédents qui seront transférées dans le
+      nouveau mois.
       <br />
       <span class="month-creation-step-info__total">
         Total : {{ getPendingOutflowsTotal() | currency : "EUR" }}
@@ -233,7 +304,7 @@
         <button
           class="month-creation-item__delete"
           type="button"
-          (click)="openPendingDebitDelationModal(i, $event)"
+          (click)="openPendingOutflowDelationModal(i, $event)"
         >
           <i class="fa-solid fa-trash-can"></i>
         </button>

--- a/front-v2/src/app/components/month-creation/month-creation.component.spec.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.spec.ts
@@ -21,7 +21,10 @@ describe('MonthCreationComponent', () => {
           outflows: [],
           budgets: [],
         },
-        pendingDebits: [],
+        pendingDebits: {
+          budgets: [],
+          outflows: [],
+        },
       },
     }),
   };

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -119,9 +119,7 @@ export class MonthCreationComponent implements OnInit {
         },
       };
       this.setNewMonthData();
-
       this.setForm();
-
       this.dataLoaded = true;
     });
   }
@@ -305,7 +303,7 @@ export class MonthCreationComponent implements OnInit {
           (totalExpense, expense) => totalExpense + expense.amount,
           0
         );
-        return total + budget.initialBalance + totalExpenses;
+        return total + (budget.currentBalance ?? 0) + totalExpenses;
       },
       0
     );
@@ -359,8 +357,12 @@ export class MonthCreationComponent implements OnInit {
   addPendingBudget(budget: PendingBudget) {
     const debitGroup = this.fb.group({
       name: [budget.name, Validators.required],
+      currentBalance: [
+        budget.currentBalance,
+        [Validators.required, amountValidator()],
+      ],
       initialBalance: [
-        budget.initialBalance,
+        { value: budget.initialBalance, disabled: true },
         [Validators.required, amountValidator()],
       ],
       id: [{ value: budget.id, disabled: true }],
@@ -648,8 +650,7 @@ export class MonthCreationComponent implements OnInit {
         ],
         month: this.formatToDate(raw.month),
       };
-      console.info(month);
-      // this.createNewMonth(month);
+      this.createNewMonth(month);
     } else {
       console.log('Form is invalid');
     }

--- a/front-v2/src/app/components/month-creation/month-creation.component.ts
+++ b/front-v2/src/app/components/month-creation/month-creation.component.ts
@@ -3,9 +3,12 @@ import { ActivatedRoute, Router } from '@angular/router';
 import {
   MonthCreationTemplate,
   MonthTemplate,
-  PendingDebit,
 } from '../../models/monthTemplate.model';
 import { Month, Outflow, WeeklyBudget } from '../../models/month.model';
+import {
+  Outflow as PendingOutflow,
+  Budget as PendingBudget,
+} from '../../models/monthTemplate.model';
 import {
   AbstractControl,
   FormArray,
@@ -59,7 +62,7 @@ export class MonthCreationComponent implements OnInit {
   creationLoader = false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   amountValueControl: AbstractControl<any, any> | null = null;
-  takeIntoAccountPendingDebits = true;
+  takeIntoAccountPendingOutflows = true;
   outflowsRemovedFromForecastBalance: number[] = [];
   yearlyOutflowDelationModalIsOpen = false;
   yearlyBudgetDelationModalIsOpen = false;
@@ -68,7 +71,7 @@ export class MonthCreationComponent implements OnInit {
   removeIsLoading = false;
   selectedYearlyOutflowIndex: number | null = null;
   selectedYearlyBudgetIndex: number | null = null;
-  selectedPendingDebitIndex: number | null = null;
+  selectedPendingOutflowIndex: number | null = null;
 
   newMonth: Month = {
     month: new Date(),
@@ -125,8 +128,8 @@ export class MonthCreationComponent implements OnInit {
     this.router.navigate(['monthly-templates']);
   }
 
-  togglePendingDebits() {
-    this.takeIntoAccountPendingDebits = !this.takeIntoAccountPendingDebits;
+  togglePendingOutflows() {
+    this.takeIntoAccountPendingOutflows = !this.takeIntoAccountPendingOutflows;
   }
 
   toggleYearlyOutflows() {
@@ -157,6 +160,7 @@ export class MonthCreationComponent implements OnInit {
         [Validators.required, amountValidator()],
       ],
       pendingDebits: this.fb.array([]),
+      pendingOutflows: this.fb.array([]),
       yearlyOutflows: this.fb.array([]),
       yearlyBudgets: this.fb.array([]),
       outflows: this.fb.array([]),
@@ -167,7 +171,9 @@ export class MonthCreationComponent implements OnInit {
     this.newMonth.weeklyBudgets.forEach((weeklyBudget) =>
       this.addWeeklyBudgets(weeklyBudget)
     );
-    this.template?.pendingDebits.forEach((debit) => this.addDebit(debit));
+    this.template?.pendingDebits.outflows.forEach((outflow) =>
+      this.addPendingOutflow(outflow)
+    );
     this.currentSelectedMonth = this.newMonth.month.getMonth() + 1;
     this.updateYearlyOutflowsControls(this.currentSelectedMonth);
     this.updateYearlyBudgetsControls(this.currentSelectedMonth);
@@ -237,14 +243,14 @@ export class MonthCreationComponent implements OnInit {
       },
       0
     );
-    const totalDebits = this.getPendingDebitsTotal();
+    const totalPendingOutflows = this.getPendingOutflowsTotal();
     const totalYearlyOutflows = this.getYearlyOutflowsTotal();
     const totalYearlyBudgets = this.getYearlyBudgetsTotal();
 
     let total = totalOutflows + totalWeeklyBudgets;
 
-    if (this.takeIntoAccountPendingDebits) {
-      total += totalDebits;
+    if (this.takeIntoAccountPendingOutflows) {
+      total += totalPendingOutflows;
     }
     if (this.takeIntoAccountYearlyOutflows) {
       total += totalYearlyOutflows;
@@ -258,8 +264,8 @@ export class MonthCreationComponent implements OnInit {
     return forecastBalance.toFixed(2);
   }
 
-  getPendingDebitsTotal() {
-    return (this.form.value.pendingDebits as PendingDebit[]).reduce(
+  getPendingOutflowsTotal() {
+    return (this.form.value.pendingOutflows as PendingOutflow[]).reduce(
       (total, { amount }) => {
         return total + amount;
       },
@@ -303,16 +309,13 @@ export class MonthCreationComponent implements OnInit {
   ################ Outflows managment ################
   */
 
-  addDebit(debit: PendingDebit) {
+  addPendingOutflow(outflow: PendingOutflow) {
     const debitGroup = this.fb.group({
-      label: [`🛒 ${debit.label}`, Validators.required],
-      amount: [debit.amount, [Validators.required, amountValidator()]],
-      type: [{ value: debit.type, disabled: true }],
-      id: [{ value: debit.id, disabled: true }],
-      monthId: [{ value: debit.monthId, disabled: true }],
-      monthDate: [{ value: debit.monthDate, disabled: true }],
+      label: [`🛒 ${outflow.label}`, Validators.required],
+      amount: [outflow.amount, [Validators.required, amountValidator()]],
+      id: [{ value: outflow.id, disabled: true }],
     });
-    this.pendingDebits.push(debitGroup);
+    this.pendingOutflows.push(debitGroup);
   }
 
   addYearlyOutflow(yearlyOutflow: YearlyOutflow) {
@@ -336,8 +339,8 @@ export class MonthCreationComponent implements OnInit {
     this.yearlyBudgetsControls.push(outflowGroup);
   }
 
-  get pendingDebits(): FormArray {
-    return this.form.get('pendingDebits') as FormArray;
+  get pendingOutflows(): FormArray {
+    return this.form.get('pendingOutflows') as FormArray;
   }
 
   get yearlyOutflowsControls(): FormArray {
@@ -448,19 +451,19 @@ export class MonthCreationComponent implements OnInit {
 
   openPendingDebitDelationModal(index: number, event: Event) {
     this.pendingDebitDelationModalIsOpen = true;
-    this.selectedPendingDebitIndex = index;
+    this.selectedPendingOutflowIndex = index;
     event.stopPropagation();
   }
 
   closePendingDebitDelationModal(event: Event) {
     this.pendingDebitDelationModalIsOpen = false;
-    this.selectedPendingDebitIndex = null;
+    this.selectedPendingOutflowIndex = null;
     event.stopPropagation();
   }
 
-  removePendingDebit(event: Event) {
-    if (this.selectedPendingDebitIndex !== null) {
-      this.pendingDebits.removeAt(this.selectedPendingDebitIndex);
+  removePendingOutflow(event: Event) {
+    if (this.selectedPendingOutflowIndex !== null) {
+      this.pendingOutflows.removeAt(this.selectedPendingOutflowIndex);
       this.closePendingDebitDelationModal(event);
     }
     event.stopPropagation();
@@ -553,10 +556,10 @@ export class MonthCreationComponent implements OnInit {
         name: o.name,
         initialBalance: o.initialBalance,
       }));
+      const pendingOutflows = raw.pendingOutflows;
       raw.outflows.push(...yearlyOutflows);
-      const month: Month & { pendingDebits: PendingDebit[] } = {
-        outflows: raw.outflows,
-        pendingDebits: raw.pendingDebits,
+      const month: Month = {
+        outflows: [...raw.outflows, ...pendingOutflows],
         startingBalance: raw.startingBalance,
         weeklyBudgets: [...yearlyBudgets, ...raw.weeklyBudgets],
         month: this.formatToDate(raw.month),

--- a/front-v2/src/app/models/monthTemplate.model.ts
+++ b/front-v2/src/app/models/monthTemplate.model.ts
@@ -1,3 +1,5 @@
+import { Expense } from './monthlyBudget.model';
+
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 export type MonthTemplate = {
   id: string;
@@ -13,6 +15,7 @@ export type Budget = {
   id: string;
   name: string;
   initialBalance: number;
+  expenses?: Expense[];
 };
 
 export type Outflow = {
@@ -22,16 +25,10 @@ export type Outflow = {
   isChecked: boolean;
 };
 
-export type PendingDebit = {
-  id: string;
-  monthId: string;
-  monthDate: Date;
-  label: string;
-  amount: number;
-  type: 'outflow' | 'expense';
-};
-
 export type MonthCreationTemplate = {
   template: MonthTemplate;
-  pendingDebits: PendingDebit[];
+  pendingDebits: {
+    outflows: Outflow[];
+    budgets: Budget[];
+  };
 };

--- a/front-v2/src/app/models/monthTemplate.model.ts
+++ b/front-v2/src/app/models/monthTemplate.model.ts
@@ -15,6 +15,7 @@ export type Budget = {
   id: string;
   name: string;
   initialBalance: number;
+  currentBalance?: number;
   expenses?: Expense[];
 };
 

--- a/front-v2/src/app/validators/amount.validator.ts
+++ b/front-v2/src/app/validators/amount.validator.ts
@@ -4,7 +4,7 @@ export function amountValidator(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value = control.value;
 
-    const decimalPattern = /^\d+(\.\d{1,2})?$/;
+    const decimalPattern = /^-?\d+(\.\d{1,2})?$/;
     const valid = decimalPattern.test(value);
 
     return valid ? null : { invalidDecimal: true };


### PR DESCRIPTION
### Back

**Remonter les budgets des mois non supprimés selon ces critères :**

- Le budget possède des dépenses non prélevées
- Le budget a un solde courant de + de 0€.
- Le nom du budget est modifié en `"{name} (Fév. 2024)"`
- On remonte le budget avec ses dépenses non prélevées (liste vide si aucune dépense non prélevée)

### Front

Afficher un bloc pour chaque budget non fini avec sa liste de dépenses non prélevées (peut être vide)

**Cas d'un budget avec des dépenses non prélevées**
Texte : *Ce budget possède `n` dépenses non prélevées. Il sera transféré dans le nouveau mois.*

**Quand on submit le formulaire :**
On renvoi le pending-budget avec ses dépenses non prélevées. Son solde initial devient son solde courant.

**Cas d'un budget qui a un solde courant supérieur à 0**
Texte : *Ce budget n'a pas été soldé. Il sera transféré dans le nouveau mois*
Bouton delete.

**Quand on submit le formulaire :**
**Budget pas supprimé:** On renvoi le pending-budget. Son solde initial devient son solde courant.
**Budget supprimé:** On ne renvoi pas le pending-budget.