### PR TITLE
[UX] Mieux séparer visuellement les pending ainsi que les blocs

### DIFF
--- a/front-v2/src/app/components/expenses/expenses.component.html
+++ b/front-v2/src/app/components/expenses/expenses.component.html
@@ -28,7 +28,7 @@
   class="expenses"
   [ngStyle]="{ 'padding-bottom': formUpdated ? '80px' : 0 }"
 >
-  @if(form && expensesFormArray) {
+  @if(form && weeks.length > 0) {
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
     <div class="expenses-list" formArrayName="expenses">
       <div class="expenses-list__header">
@@ -48,8 +48,10 @@
           >
         </div>
       </div>
-      <ng-container *ngFor="let week of weeks; let i = index">
-        @let pending = getPendingInfo(week.id);
+      @if(pendingBudgets.length > 0) {
+      <div class="header header--pending">Budgets des mois précédents</div>
+      }
+      <ng-container *ngFor="let week of pendingBudgets; let i = index">
         <app-card>
           <div class="expenses-list__week">
             <div class="expenses-list__week__header">
@@ -59,10 +61,7 @@
                 (toggle)="updateFilterState($event)"
               ></app-tab-button>
               <span
-                class="expenses-list__week-name"
-                [ngClass]="{
-                  'expenses-list__week-name--pending': pending !== null
-                }"
+                class="expenses-list__week-name expenses-list__week-name--pending"
               >
                 {{ week.name }}
               </span>
@@ -96,11 +95,120 @@
               </button>
             </div>
             <div class="expenses-list__infos">
-              @if(pending !== null) {
               <span class="expenses-list__pending">
-                ({{ pending | shortDate }})
+                ({{ getPendingInfo(week.id) | shortDate }})
               </span>
-              }&nbsp;
+              &nbsp;
+              {{ getBudgetsInfos(week.id) }}
+            </div>
+            <div class="expenses-list__balance">
+              <span>Solde :</span>
+              <app-progress-bar
+                [currentValue]="getCurrentBalanceByWeekId(week.id)"
+                [total]="getInitialBalanceByWeekId(week.id)"
+              ></app-progress-bar>
+            </div>
+            @if (filterIsActive(week.id)) { @if
+            (getExpensesFormGroupByWeekId(week.id).length === 0) {
+            <app-tips>
+              <p>Vous n'avez pas encore crée de dépenses pour ce budget 🙂</p>
+              <img width="50%" src="info/no-expenses-yet.png" alt="" />
+            </app-tips>
+            } @else {
+            <app-item
+              *ngFor="
+                let expense of getExpensesFormGroupByWeekId(week.id);
+                let i = index
+              "
+              [formGroupName]="i"
+            >
+              <button
+                type="button"
+                [ngClass]="{
+                  'expenses-list-item--checked': isExpenseItemChecked(expense)
+                }"
+                class="expenses-list-item"
+                (click)="toggleExpenseAtIndex(expense, $event)"
+              >
+                <span class="expenses-list-item__icon">
+                  <i class="fa-solid fa-basket-shopping"></i>
+                </span>
+                <div
+                  [ngClass]="{
+                    'expenses-list-item__info--checked':
+                      isExpenseItemChecked(expense)
+                  }"
+                  class="expenses-list-item__info"
+                >
+                  <span class="expenses-list-item-info__label">
+                    {{
+                      expense.get("label")?.value || "Label introuvable"
+                    }}</span
+                  >
+                  <span class="expenses-list-item-info__amount"
+                    >{{
+                      expense.get("amount")?.value || "Somme introuvable"
+                    }}€</span
+                  >
+                </div>
+
+                <button
+                  class="expenses-list-item__delete"
+                  type="button"
+                  (click)="openExpenseDelationModal(expense, $event)"
+                >
+                  <i class="fa-solid fa-trash-can"></i>
+                </button>
+              </button>
+            </app-item>
+            } }
+          </div>
+        </app-card>
+      </ng-container>
+
+      <div class="header">Budgets du mois en cours</div>
+      <ng-container *ngFor="let week of regularBudgets; let i = index">
+        <app-card>
+          <div class="expenses-list__week">
+            <div class="expenses-list__week__header">
+              <app-tab-button
+                [id]="week.id"
+                [isFolded]="!filterIsActive(week.id)"
+                (toggle)="updateFilterState($event)"
+              ></app-tab-button>
+              <span class="expenses-list__week-name">
+                {{ week.name }}
+              </span>
+              <button
+                class="expenses-list__week-add"
+                type="button"
+                (click)="openUpdateBudgetModal(week.id)"
+              >
+                <i class="fa-solid fa-edit"></i>
+              </button>
+              <button
+                class="expenses-list__week-transfer"
+                type="button"
+                (click)="openRemoveBudgetModal(week.id)"
+              >
+                <i class="fa-solid fa-trash-can"></i>
+              </button>
+              <button
+                class="expenses-list__week-add"
+                type="button"
+                (click)="openExpensesModal(week.id)"
+              >
+                <i class="fa-solid fa-plus"></i>
+              </button>
+              <button
+                class="expenses-list__week-transfer"
+                type="button"
+                (click)="openTransferChoiceModal(week, $event)"
+              >
+                <i class="fa-solid fa-right-left"></i>
+              </button>
+            </div>
+            <div class="expenses-list__infos">
               {{ getBudgetsInfos(week.id) }}
             </div>
             <div class="expenses-list__balance">
@@ -180,15 +288,15 @@
     </div>
     }
   </form>
-  <button class="add-budget" (click)="openAddBudgetModal()">
-    <i class="fa-solid fa-plus"></i>
-  </button>
   } @else {
   <app-tips>
     <p>Vous n'avez pas encore crée de budgets pour ce mois 🙂</p>
     <img width="70%" src="info/no-budgets-yet.png" alt="" />
   </app-tips>
   }
+  <button class="add-budget" (click)="openAddBudgetModal()">
+    <i class="fa-solid fa-plus"></i>
+  </button>
 </div>
 
 @if(addExpenseForm) {

--- a/front-v2/src/app/components/expenses/expenses.component.html
+++ b/front-v2/src/app/components/expenses/expenses.component.html
@@ -23,6 +23,7 @@
     (click)="removeBudget($event)"
   ></app-button>
 </app-modal>
+
 <div
   class="expenses"
   [ngStyle]="{ 'padding-bottom': formUpdated ? '80px' : 0 }"
@@ -49,124 +50,122 @@
       </div>
       <ng-container *ngFor="let week of weeks; let i = index">
         @let pending = getPendingInfo(week.id);
-        <div class="expenses-list__week">
-          <div class="expenses-list__week__header">
-            <button
-              class="expenses-list__week-hide"
-              [ngClass]="{
-                'expenses-list__week-hide--folded': !filterIsActive(week.id)
-              }"
-              type="button"
-              (click)="updateFilterState(week.id)"
-            >
-              <i class="fa-solid fa-chevron-right"></i>
-            </button>
-            <span
-              class="expenses-list__week-name"
-              [ngClass]="{
-                'expenses-list__week-name--pending': pending !== null
-              }"
-            >
-              {{ week.name }}
-            </span>
-            <button
-              class="expenses-list__week-add"
-              type="button"
-              (click)="openUpdateBudgetModal(week.id)"
-            >
-              <i class="fa-solid fa-edit"></i>
-            </button>
-            <button
-              class="expenses-list__week-transfer"
-              type="button"
-              (click)="openRemoveBudgetModal(week.id)"
-            >
-              <i class="fa-solid fa-trash-can"></i>
-            </button>
-            <button
-              class="expenses-list__week-add"
-              type="button"
-              (click)="openExpensesModal(week.id)"
-            >
-              <i class="fa-solid fa-plus"></i>
-            </button>
-            <button
-              class="expenses-list__week-transfer"
-              type="button"
-              (click)="openTransferChoiceModal(week, $event)"
-            >
-              <i class="fa-solid fa-right-left"></i>
-            </button>
-          </div>
-          <div class="expenses-list__infos">
-            @if(pending !== null) {
-            <span class="expenses-list__pending">
-              ({{ pending | shortDate }})
-            </span>
-            }&nbsp;
-            {{ getBudgetsInfos(week.id) }}
-          </div>
-          <div class="expenses-list__balance">
-            <span>Solde :</span>
-            <app-progress-bar
-              [currentValue]="getCurrentBalanceByWeekId(week.id)"
-              [total]="getInitialBalanceByWeekId(week.id)"
-            ></app-progress-bar>
-          </div>
-          @if (filterIsActive(week.id)) { @if
-          (getExpensesFormGroupByWeekId(week.id).length === 0) {
-          <app-tips>
-            <p>Vous n'avez pas encore crée de dépenses pour ce budget 🙂</p>
-            <img width="50%" src="info/no-expenses-yet.png" alt="" />
-          </app-tips>
-          } @else {
-          <app-item
-            *ngFor="
-              let expense of getExpensesFormGroupByWeekId(week.id);
-              let i = index
-            "
-            [formGroupName]="i"
-          >
-            <button
-              type="button"
-              [ngClass]="{
-                'expenses-list-item--checked': isExpenseItemChecked(expense)
-              }"
-              class="expenses-list-item"
-              (click)="toggleExpenseAtIndex(expense, $event)"
-            >
-              <span class="expenses-list-item__icon">
-                <i class="fa-solid fa-basket-shopping"></i>
-              </span>
-              <div
+        <app-card>
+          <div class="expenses-list__week">
+            <div class="expenses-list__week__header">
+              <app-tab-button
+                [id]="week.id"
+                [isFolded]="!filterIsActive(week.id)"
+                (toggle)="updateFilterState($event)"
+              ></app-tab-button>
+              <span
+                class="expenses-list__week-name"
                 [ngClass]="{
-                  'expenses-list-item__info--checked':
-                    isExpenseItemChecked(expense)
+                  'expenses-list__week-name--pending': pending !== null
                 }"
-                class="expenses-list-item__info"
               >
-                <span class="expenses-list-item-info__label">
-                  {{ expense.get("label")?.value || "Label introuvable" }}</span
-                >
-                <span class="expenses-list-item-info__amount"
-                  >{{
-                    expense.get("amount")?.value || "Somme introuvable"
-                  }}€</span
-                >
-              </div>
-
+                {{ week.name }}
+              </span>
               <button
-                class="expenses-list-item__delete"
+                class="expenses-list__week-add"
                 type="button"
-                (click)="openExpenseDelationModal(expense, $event)"
+                (click)="openUpdateBudgetModal(week.id)"
+              >
+                <i class="fa-solid fa-edit"></i>
+              </button>
+              <button
+                class="expenses-list__week-transfer"
+                type="button"
+                (click)="openRemoveBudgetModal(week.id)"
               >
                 <i class="fa-solid fa-trash-can"></i>
               </button>
-            </button>
-          </app-item>
-          } }
-        </div>
-        <app-divider></app-divider>
+              <button
+                class="expenses-list__week-add"
+                type="button"
+                (click)="openExpensesModal(week.id)"
+              >
+                <i class="fa-solid fa-plus"></i>
+              </button>
+              <button
+                class="expenses-list__week-transfer"
+                type="button"
+                (click)="openTransferChoiceModal(week, $event)"
+              >
+                <i class="fa-solid fa-right-left"></i>
+              </button>
+            </div>
+            <div class="expenses-list__infos">
+              @if(pending !== null) {
+              <span class="expenses-list__pending">
+                ({{ pending | shortDate }})
+              </span>
+              }&nbsp;
+              {{ getBudgetsInfos(week.id) }}
+            </div>
+            <div class="expenses-list__balance">
+              <span>Solde :</span>
+              <app-progress-bar
+                [currentValue]="getCurrentBalanceByWeekId(week.id)"
+                [total]="getInitialBalanceByWeekId(week.id)"
+              ></app-progress-bar>
+            </div>
+            @if (filterIsActive(week.id)) { @if
+            (getExpensesFormGroupByWeekId(week.id).length === 0) {
+            <app-tips>
+              <p>Vous n'avez pas encore crée de dépenses pour ce budget 🙂</p>
+              <img width="50%" src="info/no-expenses-yet.png" alt="" />
+            </app-tips>
+            } @else {
+            <app-item
+              *ngFor="
+                let expense of getExpensesFormGroupByWeekId(week.id);
+                let i = index
+              "
+              [formGroupName]="i"
+            >
+              <button
+                type="button"
+                [ngClass]="{
+                  'expenses-list-item--checked': isExpenseItemChecked(expense)
+                }"
+                class="expenses-list-item"
+                (click)="toggleExpenseAtIndex(expense, $event)"
+              >
+                <span class="expenses-list-item__icon">
+                  <i class="fa-solid fa-basket-shopping"></i>
+                </span>
+                <div
+                  [ngClass]="{
+                    'expenses-list-item__info--checked':
+                      isExpenseItemChecked(expense)
+                  }"
+                  class="expenses-list-item__info"
+                >
+                  <span class="expenses-list-item-info__label">
+                    {{
+                      expense.get("label")?.value || "Label introuvable"
+                    }}</span
+                  >
+                  <span class="expenses-list-item-info__amount"
+                    >{{
+                      expense.get("amount")?.value || "Somme introuvable"
+                    }}€</span
+                  >
+                </div>
+
+                <button
+                  class="expenses-list-item__delete"
+                  type="button"
+                  (click)="openExpenseDelationModal(expense, $event)"
+                >
+                  <i class="fa-solid fa-trash-can"></i>
+                </button>
+              </button>
+            </app-item>
+            } }
+          </div>
+        </app-card>
       </ng-container>
     </div>
     @if(formUpdated) {

--- a/front-v2/src/app/components/expenses/expenses.component.scss
+++ b/front-v2/src/app/components/expenses/expenses.component.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding-bottom: 40px;
+  padding-bottom: 80px;
     
   &__pending {
     @extend %text-5;
@@ -97,6 +97,20 @@
       gap: 0;
       width: 0px;
       border-radius: 0;
+    }
+  }
+
+  .header {
+    @extend %text-5;
+    
+    border-radius: 5px;
+    padding: 5px;
+    font-weight: bold;
+  
+    &--pending {
+      background-color: var(--color-700);
+      color: var(--color-300);
+      border: 0px;
     }
   }
 

--- a/front-v2/src/app/components/expenses/expenses.component.scss
+++ b/front-v2/src/app/components/expenses/expenses.component.scss
@@ -1,11 +1,11 @@
 @import "../../../styles/variables";
 @import "../../../styles/typo";
-@import "../../../styles/input";
+@import "../../../styles/tags";
 
 .expenses-list {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 10px;
   padding-bottom: 40px;
     
   &__pending {

--- a/front-v2/src/app/components/expenses/expenses.component.ts
+++ b/front-v2/src/app/components/expenses/expenses.component.ts
@@ -234,9 +234,25 @@ export class ExpensesComponent implements AfterViewInit {
     if (budget) {
       return budget.pendingFrom
         ? new Date(budget.pendingFrom)?.toISOString()
-        : null;
+        : '';
     }
-    return null;
+    return '';
+  }
+
+  get pendingBudgets() {
+    return (
+      this.month()?.account.weeklyBudgets.filter(
+        (b) => b.pendingFrom !== null && b.pendingFrom !== undefined
+      ) ?? []
+    );
+  }
+
+  get regularBudgets() {
+    return (
+      this.month()?.account.weeklyBudgets.filter(
+        (b) => b.pendingFrom === null || b.pendingFrom === undefined
+      ) ?? []
+    );
   }
 
   getInitialBalanceByWeekId(weekId: string) {

--- a/front-v2/src/app/components/monthly-template/monthly-template.component.html
+++ b/front-v2/src/app/components/monthly-template/monthly-template.component.html
@@ -13,17 +13,26 @@
     ></app-button-icon>
   </div>
   <div class="template__infos">
-    <app-toggle-button
-      (toggleChange)="defaultChanged($event)"
-      [disabled]="isLoading"
-      [isToggled]="editingTemplate.isDefault"
-    ></app-toggle-button>
-    <span>
-      {{ isDefaultInfo }}
-      @if(isLoading) { &nbsp;
-      <i class="fa-solid fa-arrows-rotate rotate"></i>
-      }
-    </span>
+    <div class="template-infos__default">
+      <app-toggle-button
+        (toggleChange)="defaultChanged($event)"
+        [disabled]="isLoading"
+        [isToggled]="editingTemplate.isDefault"
+      ></app-toggle-button>
+      <span>
+        {{ isDefaultInfo }}
+        @if(isLoading) { &nbsp;
+        <i class="fa-solid fa-arrows-rotate rotate"></i>
+        }
+      </span>
+    </div>
+    <div class="expenses-list__filters">
+      <app-button-link
+        class="expenses-list-filters__link"
+        (onClick)="toggleSectionsUnfolded()"
+        >{{ unfoldSectionsLabel }}</app-button-link
+      >
+    </div>
   </div>
   <div class="template__details">
     <app-card>

--- a/front-v2/src/app/components/monthly-template/monthly-template.component.html
+++ b/front-v2/src/app/components/monthly-template/monthly-template.component.html
@@ -25,95 +25,152 @@
       }
     </span>
   </div>
-  <section>
-    <div class="subtitle">
-      Sorties mensuelles
-      <app-button-icon
-        icon="fa-plus"
-        size="small"
-        [disabled]="isLoading"
-        (click)="openAddOutflowModal()"
-      ></app-button-icon>
-    </div>
-    <div class="outflows__list">
-      @if (editingTemplate.outflows.length === 0) {
-      <app-tips>
-        <p>Aucune sortie mensuelle pour le moment 🙂</p>
-        <img width="70%" src="info/no-outflows-yet.png" alt="" />
-      </app-tips>
-      } @else {
-      <app-item *ngFor="let outflow of editingTemplate.outflows; let i = index">
-        <button type="button" class="outflows-list-item">
-          <span class="outflows-list-item__icon">
-            <i class="fa-solid fa-money-bill-transfer"></i>
-          </span>
-          <div class="outflows-list-item__info">
-            <span class="outflows-list-item-info__label">
-              {{ outflow.label }}</span
-            >
-            <span class="outflows-list-item-info__amount">{{
-              outflow.amount | currency : "EUR"
-            }}</span>
+  <div class="template__details">
+    <app-card>
+      <section>
+        <div class="subtitle">
+          <app-tab-button
+            [id]="'outflows'"
+            [isFolded]="sectionIsFolded('outflows')"
+            (toggle)="toggleSection('outflows')"
+          ></app-tab-button>
+          <div class="subtitle__infos">
+            <span class="subtitle-infos__title">Sorties mensuelles</span>
+            <span class="subtitle-infos__infos">
+              {{
+                editingTemplate.outflows.length
+                  | i18nPlural
+                    : {
+                        "=0": "aucune sortie",
+                        "=1": "une sortie",
+                        other: "# sorties"
+                      }
+              }}
+              <span class="subtotal">{{
+                outflowsTotal | currency : "EUR"
+              }}</span>
+            </span>
           </div>
-
-          <button
-            class="outflows-list-item__delete"
-            type="button"
+          <app-button-icon
+            icon="fa-plus"
+            size="small"
             [disabled]="isLoading"
-            (click)="openOutflowDelationModal(outflow, $event)"
+            (click)="openAddOutflowModal()"
+          ></app-button-icon>
+        </div>
+        <div
+          class="outflows__list"
+          [ngClass]="{ 'outflows__list--hide': sectionIsFolded('outflows') }"
+        >
+          @if (editingTemplate.outflows.length === 0) {
+          <app-tips>
+            <p>Aucune sortie mensuelle pour le moment 🙂</p>
+            <img width="70%" src="info/no-outflows-yet.png" alt="" />
+          </app-tips>
+          } @else {
+          <app-item
+            *ngFor="let outflow of editingTemplate.outflows; let i = index"
           >
-            <i class="fa-solid fa-trash-can"></i>
-          </button>
-        </button>
-      </app-item>
-      }
-    </div>
-  </section>
-  <app-divider></app-divider>
-  <section>
-    <div class="subtitle">
-      Budgets
-      <app-button-icon
-        icon="fa-plus"
-        size="small"
-        [disabled]="isLoading"
-        (click)="openAddBudgetModal()"
-      ></app-button-icon>
-    </div>
-    <div class="outflows__list">
-      @if (editingTemplate.budgets.length === 0) {
-      <app-tips>
-        <p>Aucun budget mensuel pour le moment 🙂</p>
-        <img width="70%" src="info/no-budgets-yet.png" alt="" />
-      </app-tips>
-      } @else {
-      <app-item *ngFor="let budget of editingTemplate.budgets; let i = index">
-        <button type="button" class="outflows-list-item">
-          <span class="outflows-list-item__icon">
-            <i class="fa-solid fa-basket-shopping"></i>
-          </span>
-          <div class="outflows-list-item__info">
-            <span class="outflows-list-item-info__label">
-              {{ budget.name }}</span
-            >
-            <span class="outflows-list-item-info__amount">{{
-              budget.initialBalance | currency : "EUR"
-            }}</span>
+            <button type="button" class="outflows-list-item">
+              <span class="outflows-list-item__icon">
+                <i class="fa-solid fa-money-bill-transfer"></i>
+              </span>
+              <div class="outflows-list-item__info">
+                <span class="outflows-list-item-info__label">
+                  {{ outflow.label }}</span
+                >
+                <span class="outflows-list-item-info__amount">{{
+                  outflow.amount | currency : "EUR"
+                }}</span>
+              </div>
+
+              <button
+                class="outflows-list-item__delete"
+                type="button"
+                [disabled]="isLoading"
+                (click)="openOutflowDelationModal(outflow, $event)"
+              >
+                <i class="fa-solid fa-trash-can"></i>
+              </button>
+            </button>
+          </app-item>
+          }
+        </div>
+      </section>
+    </app-card>
+    <app-card>
+      <section>
+        <div class="subtitle">
+          <app-tab-button
+            [id]="'budgets'"
+            [isFolded]="sectionIsFolded('budgets')"
+            (toggle)="toggleSection('budgets')"
+          ></app-tab-button>
+          <div class="subtitle__infos">
+            <span class="subtitle-infos__title">Budgets</span>
+            <span class="subtitle-infos__infos">
+              {{
+                editingTemplate.budgets.length
+                  | i18nPlural
+                    : {
+                        "=0": "aucun budget",
+                        "=1": "un budget",
+                        other: "# budgets"
+                      }
+              }}
+              <span class="subtotal">{{
+                budgetsTotal | currency : "EUR"
+              }}</span>
+            </span>
           </div>
-
-          <button
-            class="outflows-list-item__delete"
-            type="button"
+          <app-button-icon
+            icon="fa-plus"
+            size="small"
             [disabled]="isLoading"
-            (click)="openBudgetDelationModal(budget, $event)"
+            (click)="openAddBudgetModal()"
+          ></app-button-icon>
+        </div>
+        <div
+          class="outflows__list"
+          [ngClass]="{ 'outflows__list--hide': sectionIsFolded('budgets') }"
+        >
+          @if (editingTemplate.budgets.length === 0) {
+          <app-tips>
+            <p>Aucun budget mensuel pour le moment 🙂</p>
+            <img width="70%" src="info/no-budgets-yet.png" alt="" />
+          </app-tips>
+          } @else {
+          <app-item
+            *ngFor="let budget of editingTemplate.budgets; let i = index"
           >
-            <i class="fa-solid fa-trash-can"></i>
-          </button>
-        </button>
-      </app-item>
-      }
-    </div>
-  </section>
+            <button type="button" class="outflows-list-item">
+              <span class="outflows-list-item__icon">
+                <i class="fa-solid fa-basket-shopping"></i>
+              </span>
+              <div class="outflows-list-item__info">
+                <span class="outflows-list-item-info__label">
+                  {{ budget.name }}</span
+                >
+                <span class="outflows-list-item-info__amount">{{
+                  budget.initialBalance | currency : "EUR"
+                }}</span>
+              </div>
+
+              <button
+                class="outflows-list-item__delete"
+                type="button"
+                [disabled]="isLoading"
+                (click)="openBudgetDelationModal(budget, $event)"
+              >
+                <i class="fa-solid fa-trash-can"></i>
+              </button>
+            </button>
+          </app-item>
+          }
+        </div>
+      </section>
+    </app-card>
+  </div>
   }
 </div>
 

--- a/front-v2/src/app/components/monthly-template/monthly-template.component.scss
+++ b/front-v2/src/app/components/monthly-template/monthly-template.component.scss
@@ -1,6 +1,6 @@
 @import "../../../styles/variables";
 @import "../../../styles/typo";
-@import "../../../styles/input";
+@import "../../../styles/tags";
 
 .content {
     margin-top: 40px;
@@ -16,11 +16,24 @@ section {
     margin: 10px 0;
 }
 
+.subtotal {
+  @extend %text-5;
+
+  color: var(--color-800);
+}
+
 .template {
   &__infos {
     display: flex;
     flex-direction: row;
     align-items: center;
+    gap: 10px;
+  }
+  
+  &__details {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
     gap: 10px;
   }
 }
@@ -41,13 +54,28 @@ section {
 }
 
 .subtitle {
-    @extend %title-3;
-    
     margin: 5px 0;
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 10px;
+
+    &__infos {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 5px;
+    }
+}
+
+.subtitle-infos {
+  &__title {
+    @extend %title-3;
+  }
+
+  &__infos {
+    @extend %text-7;
+  }
 }
 
 .outflows {
@@ -56,6 +84,10 @@ section {
         flex-direction: column;
         gap: 10px;
         padding-bottom: 10px;
+
+        &--hide {
+          display: none;
+        }
     }
 }
 

--- a/front-v2/src/app/components/monthly-template/monthly-template.component.scss
+++ b/front-v2/src/app/components/monthly-template/monthly-template.component.scss
@@ -27,6 +27,7 @@ section {
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: space-between;
     gap: 10px;
   }
   
@@ -34,6 +35,15 @@ section {
     margin-top: 10px;
     display: flex;
     flex-direction: column;
+    gap: 10px;
+  }
+}
+
+.template-infos {
+  &__default {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     gap: 10px;
   }
 }

--- a/front-v2/src/app/components/monthly-template/monthly-template.component.ts
+++ b/front-v2/src/app/components/monthly-template/monthly-template.component.ts
@@ -60,6 +60,7 @@ export class MonthlyTemplateComponent implements OnInit {
   isNumpadModalOpen = false;
   // tabs
   activeTabs: Sections[] = [];
+  sectionsUnfolded = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -118,6 +119,19 @@ export class MonthlyTemplateComponent implements OnInit {
         return prev + curr.initialBalance;
       }, 0) ?? 0
     );
+  }
+
+  toggleSectionsUnfolded() {
+    this.sectionsUnfolded = !this.sectionsUnfolded;
+    if (this.sectionsUnfolded) {
+      this.activeTabs = ['outflows', 'budgets'];
+    } else {
+      this.activeTabs = [];
+    }
+  }
+
+  get unfoldSectionsLabel() {
+    return this.sectionsUnfolded ? 'Tout replier' : 'Tout déplier';
   }
 
   get total() {

--- a/front-v2/src/app/components/monthly-template/monthly-template.component.ts
+++ b/front-v2/src/app/components/monthly-template/monthly-template.component.ts
@@ -29,6 +29,8 @@ import ToasterServiceInterface, {
 } from '../../services/toaster/toaster.service.interface';
 import { AddOutflow } from '../../services/months/months.service.interface';
 
+type Sections = 'outflows' | 'budgets';
+
 @Component({
   selector: 'app-monthly-template',
   standalone: true,
@@ -56,6 +58,8 @@ export class MonthlyTemplateComponent implements OnInit {
   editingBudget: AddingBudget | null = null;
   // numpad
   isNumpadModalOpen = false;
+  // tabs
+  activeTabs: Sections[] = [];
 
   constructor(
     private route: ActivatedRoute,
@@ -68,6 +72,18 @@ export class MonthlyTemplateComponent implements OnInit {
 
   ngOnInit(): void {
     this.initializeEditingTemplate();
+  }
+
+  toggleSection(section: Sections) {
+    if (this.activeTabs.includes(section)) {
+      this.activeTabs = this.activeTabs.filter((tab) => tab !== section);
+    } else {
+      this.activeTabs.push(section);
+    }
+  }
+
+  sectionIsFolded(section: Sections): boolean {
+    return this.activeTabs.includes(section) === false;
   }
 
   initializeEditingTemplate() {
@@ -88,16 +104,24 @@ export class MonthlyTemplateComponent implements OnInit {
     return this.editingTemplateSignal();
   }
 
-  get total() {
-    const totalOutflows =
+  get outflowsTotal() {
+    return (
       this.editingTemplate?.outflows.reduce((prev, curr) => {
         return prev + curr.amount;
-      }, 0) ?? 0;
-    const totalBudgets =
+      }, 0) ?? 0
+    );
+  }
+
+  get budgetsTotal() {
+    return (
       this.editingTemplate?.budgets.reduce((prev, curr) => {
         return prev + curr.initialBalance;
-      }, 0) ?? 0;
-    return totalBudgets + totalOutflows;
+      }, 0) ?? 0
+    );
+  }
+
+  get total() {
+    return this.budgetsTotal + this.outflowsTotal;
   }
 
   get template(): MonthTemplate | null {

--- a/front-v2/src/app/components/monthly-templates/monthly-templates.component.html
+++ b/front-v2/src/app/components/monthly-templates/monthly-templates.component.html
@@ -8,20 +8,21 @@
   </app-tips>
   } @else {
   <section class="content__template" *ngFor="let template of templates">
-    <div class="content-template__content">
-      <div class="content-template-content__title">
-        {{ template.name }}&nbsp;<span
-          class="content-template-content-title__infos"
-          >{{ getDefaultInfo(template) }}</span
-        >
+    <app-card>
+      <div class="content-template__content">
+        <div class="content-template-content__title">
+          {{ template.name }}&nbsp;<span
+            class="content-template-content-title__infos"
+            >{{ getDefaultInfo(template) }}</span
+          >
+        </div>
+        <app-button-icon
+          icon="fa-eye"
+          size="small"
+          (click)="goToTemplatePage(template.id, $event)"
+        ></app-button-icon>
       </div>
-      <app-button-icon
-        icon="fa-eye"
-        size="small"
-        (click)="goToTemplatePage(template.id, $event)"
-      ></app-button-icon>
-    </div>
-    <app-divider></app-divider>
+    </app-card>
   </section>
   }
 </div>

--- a/front-v2/src/app/components/outflows/outflows.component.html
+++ b/front-v2/src/app/components/outflows/outflows.component.html
@@ -44,60 +44,106 @@
         </button>
       </div>
       <div class="outflows-list" formArrayName="outflows">
-        <app-item
-          *ngFor="let outflow of outflowsFormArray.controls; let i = index"
-          [formGroupName]="i"
-        >
-          @let pending = getPendingInfo(outflow);
-          <button
-            type="button"
-            [ngClass]="{
-              'outflows-list-item--checked': isOutflowItemChecked(i)
-            }"
-            class="outflows-list-item"
-            (click)="toggleOutflowAtIndex(i, $event)"
+        @if (pendingOutflows.length > 0) {
+        <app-card>
+          <div class="header header--pending">Sorties des mois précédents</div>
+          <app-item
+            *ngFor="let outflow of pendingOutflows; let i = index"
+            [formGroupName]="i"
           >
-            <span class="outflows-list-item__icon">
-              <i class="fa-solid fa-money-bill-transfer"></i>
-            </span>
-            <div
-              [ngClass]="{
-                'outflows-list-item__info--checked': isOutflowItemChecked(i)
-              }"
-              class="outflows-list-item__info"
-            >
-              <div class="outflows-list-item-info__container">
-                <span
-                  class="outflows-list-item-info__label"
-                  [ngClass]="{
-                    'outflows-list-item-info__label--pending': pending !== null
-                  }"
-                  >{{
-                    outflow.get("label")?.value || "Label introuvable"
-                  }}</span
-                >
-                @if (pending !== null) {
-                <span class="outflows-list-item-info__pending"
-                  >({{ pending | shortDate }})</span
-                >
-                }
-              </div>
-              <span class="outflows-list-item-info__amount"
-                >{{
-                  outflow.get("amount")?.value || "Somme introuvable"
-                }}€</span
-              >
-            </div>
-
             <button
-              class="outflows-list-item__delete"
               type="button"
-              (click)="openOutflowDelationModal(outflow, $event)"
+              [ngClass]="{
+                'outflows-list-item--checked': isPendingOutflowItemChecked(i)
+              }"
+              class="outflows-list-item"
+              (click)="togglePendingOutflowAtIndex(i, $event)"
             >
-              <i class="fa-solid fa-trash-can"></i>
+              <span class="outflows-list-item__icon">
+                <i class="fa-solid fa-money-bill-transfer"></i>
+              </span>
+              <div
+                [ngClass]="{
+                  'outflows-list-item__info--checked':
+                    isPendingOutflowItemChecked(i)
+                }"
+                class="outflows-list-item__info"
+              >
+                <div class="outflows-list-item-info__container">
+                  <span
+                    class="outflows-list-item-info__label outflows-list-item-info__label--pending"
+                    >{{
+                      outflow.get("label")?.value || "Label introuvable"
+                    }}</span
+                  >
+                  <span class="outflows-list-item-info__pending"
+                    >({{ getPendingInfo(outflow) | shortDate }})</span
+                  >
+                </div>
+                <span class="outflows-list-item-info__amount"
+                  >{{
+                    outflow.get("amount")?.value || "Somme introuvable"
+                  }}€</span
+                >
+              </div>
+
+              <button
+                class="outflows-list-item__delete"
+                type="button"
+                (click)="openOutflowDelationModal(outflow, $event)"
+              >
+                <i class="fa-solid fa-trash-can"></i>
+              </button>
             </button>
-          </button>
-        </app-item>
+          </app-item>
+        </app-card>
+        }
+
+        <app-card>
+          <div class="header">Sorties du mois en cours</div>
+          <app-item
+            *ngFor="let outflow of regularOutflows; let i = index"
+            [formGroupName]="i"
+          >
+            <button
+              type="button"
+              [ngClass]="{
+                'outflows-list-item--checked': isOutflowItemChecked(i)
+              }"
+              class="outflows-list-item"
+              (click)="toggleOutflowAtIndex(i, $event)"
+            >
+              <span class="outflows-list-item__icon">
+                <i class="fa-solid fa-money-bill-transfer"></i>
+              </span>
+              <div
+                [ngClass]="{
+                  'outflows-list-item__info--checked': isOutflowItemChecked(i)
+                }"
+                class="outflows-list-item__info"
+              >
+                <div class="outflows-list-item-info__container">
+                  <span class="outflows-list-item-info__label">{{
+                    outflow.get("label")?.value || "Label introuvable"
+                  }}</span>
+                </div>
+                <span class="outflows-list-item-info__amount"
+                  >{{
+                    outflow.get("amount")?.value || "Somme introuvable"
+                  }}€</span
+                >
+              </div>
+
+              <button
+                class="outflows-list-item__delete"
+                type="button"
+                (click)="openOutflowDelationModal(outflow, $event)"
+              >
+                <i class="fa-solid fa-trash-can"></i>
+              </button>
+            </button>
+          </app-item>
+        </app-card>
       </div>
     </div>
     @if(formUpdated) {

--- a/front-v2/src/app/components/outflows/outflows.component.scss
+++ b/front-v2/src/app/components/outflows/outflows.component.scss
@@ -6,6 +6,16 @@
   flex-direction: column;
   gap: 10px;
   padding-bottom: 40px;
+  
+  ::ng-deep app-card {
+
+    .card {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    
+  }
 
   &__header {
     display: flex;
@@ -13,6 +23,20 @@
     gap: 10px;
     align-items: center;
     justify-content: center;
+  }
+}
+
+.header {
+  @extend %text-5;
+  
+  border-radius: 5px;
+  padding: 5px;
+  font-weight: bold;
+
+  &--pending {
+    background-color: var(--color-700);
+    color: var(--color-300);
+    border: 0px;
   }
 }
 

--- a/front-v2/src/app/components/outflows/outflows.component.ts
+++ b/front-v2/src/app/components/outflows/outflows.component.ts
@@ -129,10 +129,28 @@ export class OutflowsComponent implements AfterViewInit {
     this.outflows()!.forEach((outflow) => this.addOutflow(outflow));
   }
 
+  get pendingOutflows() {
+    if (this.outflowsFormArray) {
+      return this.outflowsFormArray.controls.filter(
+        (control) => control.get('pendingFrom')?.value !== null
+      );
+    }
+    return [];
+  }
+
+  get regularOutflows() {
+    if (this.outflowsFormArray) {
+      return this.outflowsFormArray.controls.filter(
+        (control) => control.get('pendingFrom')?.value === null
+      );
+    }
+    return [];
+  }
+
   getPendingInfo(outflow: AbstractControl<any, any>) {
     const pendingFrom = outflow.get('pendingFrom')?.value;
     if (!pendingFrom) {
-      return null;
+      return '';
     }
     return new Date(pendingFrom)?.toISOString();
   }
@@ -160,8 +178,18 @@ export class OutflowsComponent implements AfterViewInit {
   }
 
   toggleOutflowAtIndex(i: number, event: Event) {
-    const outflowControl = this.outflowsFormArray.at(i);
-    const outflowValue = this.outflowsFormArray.at(i).getRawValue();
+    const outflowControl = this.regularOutflows.at(i)!;
+    const outflowValue = outflowControl.getRawValue();
+    outflowControl.setValue({
+      ...outflowValue,
+      isChecked: !outflowValue.isChecked,
+    });
+    event.stopPropagation();
+  }
+
+  togglePendingOutflowAtIndex(i: number, event: Event) {
+    const outflowControl = this.pendingOutflows.at(i)!;
+    const outflowValue = outflowControl.getRawValue();
     outflowControl.setValue({
       ...outflowValue,
       isChecked: !outflowValue.isChecked,
@@ -182,7 +210,12 @@ export class OutflowsComponent implements AfterViewInit {
   }
 
   isOutflowItemChecked(i: number) {
-    const outflowValue = this.outflowsFormArray.at(i).getRawValue();
+    const outflowValue = this.regularOutflows.at(i)!.getRawValue();
+    return outflowValue.isChecked;
+  }
+
+  isPendingOutflowItemChecked(i: number) {
+    const outflowValue = this.pendingOutflows.at(i)!.getRawValue();
     return outflowValue.isChecked;
   }
 

--- a/front-v2/src/app/components/transfer-modals/transfer-choice/transfer-choice.component.scss
+++ b/front-v2/src/app/components/transfer-modals/transfer-choice/transfer-choice.component.scss
@@ -1,5 +1,5 @@
 @import "../../../../styles/variables";
-@import "../../../../styles/input";
+@import "../../../../styles/tags";
 
 .transfer-choice {
   display: flex;

--- a/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.html
+++ b/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.html
@@ -26,104 +26,144 @@
 <app-header-back-button></app-header-back-button>
 <div class="content">
   <ng-container *ngFor="let month of months">
-    <section class="outflows__month">
-      <div class="outflows-month__title">
-        {{ month.label }}
-      </div>
-      <div class="outflows__list">
-        <div class="outflows-list__header">
-          <div class="subtitle">Sorties</div>
-          <app-button-icon
-            icon="fa-plus"
-            size="small"
-            (click)="addOutflowToMonth(month.month, $event)"
-          ></app-button-icon>
+    <app-card>
+      <section class="outflows__month">
+        <div class="outflows-month__header">
+          <app-tab-button
+            [id]="month.label"
+            [isFolded]="sectionIsFolded(month.label)"
+            (toggle)="toggleSection(month.label)"
+          ></app-tab-button>
+          <div class="outflows-month-header__infos">
+            <span class="outflows-month-header-infos__title">{{
+              month.label
+            }}</span>
+            <span class="outflows-month-header-infos__infos">
+              {{
+                getOutflowsForMonth(month.month).length
+                  | i18nPlural
+                    : {
+                        "=0": "aucune sortie",
+                        "=1": "une sortie",
+                        other: "# sorties"
+                      }
+              }}
+              <span class="subtotal">{{
+                getOutflowsTotalForMonth(month.month) | currency : "EUR"
+              }}</span>
+              |
+              {{
+                getBudgetsForMonth(month.month).length
+                  | i18nPlural
+                    : {
+                        "=0": "aucun budget",
+                        "=1": "un budget",
+                        other: "# budgets"
+                      }
+              }}
+              <span class="subtotal">{{
+                getBudgetsTotalForMonth(month.month) | currency : "EUR"
+              }}</span>
+            </span>
+          </div>
         </div>
-        @if (getOutflowsForMonth(month.month).length === 0) {
-        <app-tips>
-          <p>Vous n'avez enregistré aucune sortie pour ce mois 🙂</p>
-          <img width="30%" src="info/no-yearly-outflows-yet.png" alt="" />
-        </app-tips>
-        } @else {
-        <div class="outflows-list__list">
-          <app-item
-            *ngFor="
-              let outflow of getOutflowsForMonth(month.month);
-              let i = index
-            "
-          >
-            <button type="button" class="outflows-list-item">
-              <span class="outflows-list-item__icon">
-                <i class="fa-solid fa-money-bill-transfer"></i>
-              </span>
-              <div class="outflows-list-item__info">
-                <span class="outflows-list-item-info__label">
-                  {{ outflow.label }}</span
-                >
-                <span class="outflows-list-item-info__amount">{{
-                  outflow.amount | currency : "EUR"
-                }}</span>
-              </div>
+        <div
+          class="outflows__list"
+          [ngClass]="{ 'outflows__list--hide': sectionIsFolded(month.label) }"
+        >
+          <div class="outflows-list__header">
+            <div class="subtitle">Sorties</div>
+            <app-button-icon
+              icon="fa-plus"
+              size="small"
+              (click)="addOutflowToMonth(month.month, $event)"
+            ></app-button-icon>
+          </div>
+          @if (getOutflowsForMonth(month.month).length === 0) {
+          <app-tips>
+            <p>Vous n'avez enregistré aucune sortie pour ce mois 🙂</p>
+            <img width="30%" src="info/no-yearly-outflows-yet.png" alt="" />
+          </app-tips>
+          } @else {
+          <div class="outflows-list__list">
+            <app-item
+              *ngFor="
+                let outflow of getOutflowsForMonth(month.month);
+                let i = index
+              "
+            >
+              <button type="button" class="outflows-list-item">
+                <span class="outflows-list-item__icon">
+                  <i class="fa-solid fa-money-bill-transfer"></i>
+                </span>
+                <div class="outflows-list-item__info">
+                  <span class="outflows-list-item-info__label">
+                    {{ outflow.label }}</span
+                  >
+                  <span class="outflows-list-item-info__amount">{{
+                    outflow.amount | currency : "EUR"
+                  }}</span>
+                </div>
 
-              <button
-                class="outflows-list-item__delete"
-                type="button"
-                (click)="openOutflowDelationModal(outflow, $event)"
-              >
-                <i class="fa-solid fa-trash-can"></i>
-              </button>
-            </button>
-          </app-item>
-        </div>
-        }
-        <div class="outflows-list__header">
-          <div class="subtitle">Budgets</div>
-          <app-button-icon
-            icon="fa-plus"
-            size="small"
-            (click)="addBudgetToMonth(month.month, $event)"
-          ></app-button-icon>
-        </div>
-        @if (getBudgetsForMonth(month.month).length === 0) {
-        <app-tips>
-          <p>Vous n'avez enregistré aucun budget pour ce mois 🙂</p>
-          <img width="30%" src="info/no-yearly-outflows-yet.png" alt="" />
-        </app-tips>
-        } @else {
-        <div class="outflows-list__list">
-          <app-item
-            *ngFor="
-              let budget of getBudgetsForMonth(month.month);
-              let i = index
-            "
-          >
-            <button type="button" class="outflows-list-item">
-              <span class="outflows-list-item__icon">
-                <i class="fa-solid fa-basket-shopping"></i>
-              </span>
-              <div class="outflows-list-item__info">
-                <span class="outflows-list-item-info__label">
-                  {{ budget.name }}</span
+                <button
+                  class="outflows-list-item__delete"
+                  type="button"
+                  (click)="openOutflowDelationModal(outflow, $event)"
                 >
-                <span class="outflows-list-item-info__amount">{{
-                  budget.initialBalance | currency : "EUR"
-                }}</span>
-              </div>
-
-              <button
-                class="outflows-list-item__delete"
-                type="button"
-                (click)="openBudgetDelationModal(budget, $event)"
-              >
-                <i class="fa-solid fa-trash-can"></i>
+                  <i class="fa-solid fa-trash-can"></i>
+                </button>
               </button>
-            </button>
-          </app-item>
+            </app-item>
+          </div>
+          }
+          <div class="outflows-list__header">
+            <div class="subtitle">Budgets</div>
+            <app-button-icon
+              icon="fa-plus"
+              size="small"
+              (click)="addBudgetToMonth(month.month, $event)"
+            ></app-button-icon>
+          </div>
+          @if (getBudgetsForMonth(month.month).length === 0) {
+          <app-tips>
+            <p>Vous n'avez enregistré aucun budget pour ce mois 🙂</p>
+            <img width="30%" src="info/no-yearly-outflows-yet.png" alt="" />
+          </app-tips>
+          } @else {
+          <div class="outflows-list__list">
+            <app-item
+              *ngFor="
+                let budget of getBudgetsForMonth(month.month);
+                let i = index
+              "
+            >
+              <button type="button" class="outflows-list-item">
+                <span class="outflows-list-item__icon">
+                  <i class="fa-solid fa-basket-shopping"></i>
+                </span>
+                <div class="outflows-list-item__info">
+                  <span class="outflows-list-item-info__label">
+                    {{ budget.name }}</span
+                  >
+                  <span class="outflows-list-item-info__amount">{{
+                    budget.initialBalance | currency : "EUR"
+                  }}</span>
+                </div>
+
+                <button
+                  class="outflows-list-item__delete"
+                  type="button"
+                  (click)="openBudgetDelationModal(budget, $event)"
+                >
+                  <i class="fa-solid fa-trash-can"></i>
+                </button>
+              </button>
+            </app-item>
+          </div>
+          }
         </div>
-        }
-      </div>
-    </section>
-    <app-divider></app-divider>
+      </section>
+    </app-card>
   </ng-container>
 </div>
 

--- a/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.html
+++ b/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.html
@@ -25,6 +25,13 @@
 
 <app-header-back-button></app-header-back-button>
 <div class="content">
+  <div class="expenses-list__filters">
+    <app-button-link
+      class="expenses-list-filters__link"
+      (onClick)="toggleSectionsUnfolded()"
+      >{{ unfoldSectionsLabel }}</app-button-link
+    >
+  </div>
   <ng-container *ngFor="let month of months">
     <app-card>
       <section class="outflows__month">

--- a/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.scss
+++ b/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.scss
@@ -28,11 +28,20 @@
   @extend %title-3;
 }
 
+.subtotal {
+  @extend %text-5;
+
+  color: var(--color-800);
+}
+
 .content {
   margin-top: 40px;
   padding: 5px;
   padding-bottom: 60px;
   box-sizing: border-box;
+  gap: 10px;
+  display: flex;
+  flex-direction: column;
 }
 
 .outflows {
@@ -59,13 +68,37 @@
             align-items: center;
           }
         }
+
+        &--hide {
+          display: none;
+        }
     }
 }
 
 .outflows-month {
-    &__title {
-      @extend %title-10;
+    &__header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
     }
+}
+
+.outflows-month-header {
+  &__infos {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+  }
+}
+
+.outflows-month-header-infos {
+  &__title {
+    @extend %title-10;
+  }
+  &__infos {
+    @extend %text-7;
+  }
 }
 
 .outflows-list {

--- a/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.scss
+++ b/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.scss
@@ -24,6 +24,13 @@
     }
 }
 
+.expenses-list {
+  &__filters {
+    display: flex;
+    justify-content: flex-end;
+  }
+}
+
 .subtitle {
   @extend %title-3;
 }
@@ -94,7 +101,7 @@
 
 .outflows-month-header-infos {
   &__title {
-    @extend %title-10;
+    @extend %title-3;
   }
   &__infos {
     @extend %text-7;

--- a/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.ts
+++ b/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.ts
@@ -60,6 +60,7 @@ export class YearlyOutflowsComponent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initialBalanceValueControl: AbstractControl<any, any> | null = null;
   activeTabs: string[] = [];
+  sectionsUnfolded = false;
 
   constructor(
     private readonly fb: FormBuilder,
@@ -124,6 +125,19 @@ export class YearlyOutflowsComponent {
         label: 'Décembre',
       },
     ];
+  }
+
+  toggleSectionsUnfolded() {
+    this.sectionsUnfolded = !this.sectionsUnfolded;
+    if (this.sectionsUnfolded) {
+      this.activeTabs = this.months.map((month) => month.label);
+    } else {
+      this.activeTabs = [];
+    }
+  }
+
+  get unfoldSectionsLabel() {
+    return this.sectionsUnfolded ? 'Tout replier' : 'Tout déplier';
   }
 
   toggleSection(section: string) {

--- a/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.ts
+++ b/front-v2/src/app/components/yearly-outflows/yearly-outflows.component.ts
@@ -59,6 +59,7 @@ export class YearlyOutflowsComponent {
   budgetDelationModalIsOpen = false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initialBalanceValueControl: AbstractControl<any, any> | null = null;
+  activeTabs: string[] = [];
 
   constructor(
     private readonly fb: FormBuilder,
@@ -125,6 +126,18 @@ export class YearlyOutflowsComponent {
     ];
   }
 
+  toggleSection(section: string) {
+    if (this.activeTabs.includes(section)) {
+      this.activeTabs = this.activeTabs.filter((tab) => tab !== section);
+    } else {
+      this.activeTabs.push(section);
+    }
+  }
+
+  sectionIsFolded(section: string): boolean {
+    return this.activeTabs.includes(section) === false;
+  }
+
   get totalAmountByMonth() {
     const yearlyOutflows = this.savings()!;
     let total = 0;
@@ -142,6 +155,11 @@ export class YearlyOutflowsComponent {
   }
 
   // BUDGETS PART
+
+  getBudgetsTotalForMonth(month: number) {
+    const budgets = this.getBudgetsForMonth(month);
+    return budgets.reduce((total, budget) => total + budget.initialBalance, 0);
+  }
 
   getBudgetsForMonth(month: number) {
     return this.savings()![month].budgets;
@@ -235,6 +253,11 @@ export class YearlyOutflowsComponent {
   }
 
   // OUTFLOWS PART
+
+  getOutflowsTotalForMonth(month: number) {
+    const outflows = this.getOutflowsForMonth(month);
+    return outflows.reduce((total, outflow) => total + outflow.amount, 0);
+  }
 
   getOutflowsForMonth(month: number) {
     return this.savings()![month].outflows;

--- a/front-v2/src/app/design-system/card/card.component.html
+++ b/front-v2/src/app/design-system/card/card.component.html
@@ -1,0 +1,3 @@
+<div class="card">
+  <ng-content></ng-content>
+</div>

--- a/front-v2/src/app/design-system/card/card.component.scss
+++ b/front-v2/src/app/design-system/card/card.component.scss
@@ -1,0 +1,10 @@
+@import "../../../styles/variables";
+@import "../../../styles/typo";
+
+.card {
+    border: 1px solid var(--light-200);
+    border-radius: 15px;
+    box-sizing: border-box;
+    padding: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}

--- a/front-v2/src/app/design-system/card/card.component.spec.ts
+++ b/front-v2/src/app/design-system/card/card.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+import { DesignSystemModule } from '../design-system.module';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CardComponent],
+      imports: [DesignSystemModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-v2/src/app/design-system/card/card.component.ts
+++ b/front-v2/src/app/design-system/card/card.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-card',
+  standalone: false,
+  templateUrl: './card.component.html',
+  styleUrl: './card.component.scss',
+})
+export class CardComponent {}

--- a/front-v2/src/app/design-system/design-system.module.ts
+++ b/front-v2/src/app/design-system/design-system.module.ts
@@ -19,6 +19,8 @@ import { ToggleButtonComponent } from './toggle-button/toggle-button.component';
 import { TipsComponent } from './tips/tips.component';
 import { ButtonLinkComponent } from './button-link/button-link.component';
 import { ScrollToTopComponent } from './scroll-to-top/scroll-to-top.component';
+import { CardComponent } from './card/card.component';
+import { TabButtonComponent } from './tab-button/tab-button.component';
 
 @NgModule({
   declarations: [
@@ -40,6 +42,8 @@ import { ScrollToTopComponent } from './scroll-to-top/scroll-to-top.component';
     TipsComponent,
     ButtonLinkComponent,
     ScrollToTopComponent,
+    CardComponent,
+    TabButtonComponent,
   ],
   imports: [CommonModule, ReactiveFormsModule],
   exports: [
@@ -61,6 +65,8 @@ import { ScrollToTopComponent } from './scroll-to-top/scroll-to-top.component';
     TipsComponent,
     ButtonLinkComponent,
     ScrollToTopComponent,
+    CardComponent,
+    TabButtonComponent,
   ],
 })
 export class DesignSystemModule {}

--- a/front-v2/src/app/design-system/input/month/month.component.scss
+++ b/front-v2/src/app/design-system/input/month/month.component.scss
@@ -1,5 +1,5 @@
 @import "../../../../styles/variables";
-@import "../../../../styles/input";
+@import "../../../../styles/tags";
 
 .input-month {
   &__input {

--- a/front-v2/src/app/design-system/input/number/number.component.scss
+++ b/front-v2/src/app/design-system/input/number/number.component.scss
@@ -1,5 +1,5 @@
 @import "../../../../styles/variables";
-@import "../../../../styles/input";
+@import "../../../../styles/tags";
 
 .input-number {
   &__input {

--- a/front-v2/src/app/design-system/input/text/text.component.scss
+++ b/front-v2/src/app/design-system/input/text/text.component.scss
@@ -1,5 +1,5 @@
 @import "../../../../styles/variables";
-@import "../../../../styles/input";
+@import "../../../../styles/tags";
 
 .input-text {
   &__input {

--- a/front-v2/src/app/design-system/tab-button/tab-button.component.html
+++ b/front-v2/src/app/design-system/tab-button/tab-button.component.html
@@ -1,0 +1,10 @@
+<button
+  class="tab"
+  [ngClass]="{
+    'tab--folded': isFolded()
+  }"
+  type="button"
+  (click)="toggleTab()"
+>
+  <i class="fa-solid fa-chevron-right"></i>
+</button>

--- a/front-v2/src/app/design-system/tab-button/tab-button.component.scss
+++ b/front-v2/src/app/design-system/tab-button/tab-button.component.scss
@@ -1,0 +1,20 @@
+@import "../../../styles/variables";
+@import "../../../styles/typo";
+@import "../../../styles/tags";
+
+.tab {
+    @extend %button;
+    color: var(--color-800);
+    font-size: 15px;
+
+    .fa-chevron-right {
+      transform: rotate(90deg);
+      transition: transform 0.3s ease;
+    }
+
+    &--folded {
+      .fa-chevron-right {
+        transform: rotate(0deg);
+      }
+    }
+}

--- a/front-v2/src/app/design-system/tab-button/tab-button.component.spec.ts
+++ b/front-v2/src/app/design-system/tab-button/tab-button.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TabButtonComponent } from './tab-button.component';
+import { DesignSystemModule } from '../design-system.module';
+
+describe('TabButtonComponent', () => {
+  let component: TabButtonComponent;
+  let fixture: ComponentFixture<TabButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TabButtonComponent],
+      imports: [DesignSystemModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-v2/src/app/design-system/tab-button/tab-button.component.ts
+++ b/front-v2/src/app/design-system/tab-button/tab-button.component.ts
@@ -1,0 +1,18 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-tab-button',
+  standalone: false,
+  templateUrl: './tab-button.component.html',
+  styleUrl: './tab-button.component.scss',
+})
+export class TabButtonComponent {
+  id = input.required<string>();
+  isFolded = input<boolean>(true);
+
+  toggle = output<string>();
+
+  toggleTab() {
+    this.toggle.emit(this.id());
+  }
+}

--- a/front-v2/src/styles.scss
+++ b/front-v2/src/styles.scss
@@ -3,7 +3,7 @@
 
 @import "styles/variables";
 @import "styles/typo";
-@import "styles/input";
+@import "styles/tags";
 
 html,
 body {

--- a/front-v2/src/styles/_tags.scss
+++ b/front-v2/src/styles/_tags.scss
@@ -11,3 +11,14 @@
   color: var(--dark-100);
   font-size: var(--text-10);
 }
+
+%button {
+  border: 0;
+  background: none;
+  justify-content: center;
+  align-items: center;
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Blocs

Mieux séparer:

- [x] chaque budget
- [x] chaque template avec des toggle pour sorties et budgets avec nombre d'items et sous total
- [x] chaque mois des économies annuelles avec des toggle pour chaque mois et le nombre de sorties et de budgets et sous total

## Pendings

Mieux séparer les pendings:

- [x] dans les budgets
- [x] dans les sorties

#195 